### PR TITLE
fix: close deferred-class-load deadlock in BreakpointTracker.tryPromotePending

### DIFF
--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/BreakpointTracker.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/BreakpointTracker.java
@@ -31,9 +31,19 @@ import java.util.concurrent.atomic.AtomicInteger;
  * normal path) or by the {@link #tryPromotePending} safety net (called from {@link JDIConnectionService#getVM()}
  * before every tool call) for classes loaded before any debugger event was delivered.
  * <p>
- * Thread-safety: all public mutators are `synchronized`; the read-mostly state maps are
- * `ConcurrentHashMap` so listeners can iterate without contending with mutators. The `lastBreakpoint*`
- * fields are `volatile` for cross-thread visibility from the JDI listener thread to MCP worker threads.
+ * <b>Thread-safety:</b> public mutators that touch state in a single critical section are
+ * {@code synchronized} on this tracker. {@link #tryPromotePending} is the exception: it cannot
+ * hold the tracker monitor across {@link JDIConnectionService#findOrForceLoadClass}, because that
+ * call parks the worker inside a target-VM {@code invokeMethod} until the JDI event listener drains
+ * the resulting events — and the listener itself takes this monitor in
+ * {@link #promotePendingFieldsForClass}. So {@code tryPromotePending} snapshots the pending maps
+ * under the monitor, releases it across each per-entry force-load round-trip, then re-acquires it
+ * for a recheck-and-mutate critical section. The promote* methods are the authoritative
+ * already-promoted guard; losers in that race tear down their orphan JDI request.
+ * <p>
+ * The read-mostly state maps are {@code ConcurrentHashMap} so listeners can iterate without
+ * contending with mutators. The {@code lastBreakpoint*} fields are {@code volatile} for cross-thread
+ * visibility from the JDI listener thread to MCP worker threads.
  */
 @Service
 public class BreakpointTracker {
@@ -420,11 +430,20 @@ public class BreakpointTracker {
 
     /**
      * Promote a pending breakpoint to active: remove from pending, add to active with the same ID.
+     * Returns {@code true} if the promotion happened. Returns {@code false} when the synthetic id
+     * already has an active entry — the listener path and the {@link #tryPromotePending} safety net
+     * race for the same pending entries, and the second arrival must not overwrite the winner.
+     * Callers that receive {@code false} are responsible for tearing down the now-orphan
+     * {@link BreakpointRequest} they just created (via {@code erm.deleteEventRequest(bp)}).
      */
-    public void promotePendingToActive(int id, BreakpointRequest bp) {
+    public synchronized boolean promotePendingToActive(int id, BreakpointRequest bp) {
+        if (breakpointsById.containsKey(id)) {
+            return false;
+        }
         pendingBreakpointsById.remove(id);
         breakpointsById.put(id, bp);
         breakpointIdsByRequest.put(bp, id);
+        return true;
     }
 
     /**
@@ -650,17 +669,26 @@ public class BreakpointTracker {
 
     /**
      * Promotes a pending exception breakpoint to active by removing it from the pending map and
-     * inserting an {@link ExceptionBreakpointInfo} under the same synthetic ID. No-op if the ID is
-     * unknown (e.g., the user removed it between class-prepare and promotion).
+     * inserting an {@link ExceptionBreakpointInfo} under the same synthetic ID. Returns {@code true}
+     * if the promotion happened. Returns {@code false} when the synthetic id already has an active
+     * entry (the listener and the {@link #tryPromotePending} safety net raced for the same pending
+     * entry — the second arrival must not overwrite the winner) or when the pending entry has
+     * already been consumed. Callers that receive {@code false} are responsible for tearing down
+     * the now-orphan {@link ExceptionRequest} they just created.
      */
-    public void promotePendingExceptionToActive(int id, ExceptionRequest req) {
-        final PendingExceptionBreakpoint pending = pendingExceptionBreakpointsById.remove(id);
-        if (pending != null) {
-            final ExceptionBreakpointInfo info = new ExceptionBreakpointInfo(pending.getSpec(), req);
-            exceptionBreakpointsById.put(id, info);
-            exceptionInfoByRequest.put(req, info);
-            exceptionIdsByRequest.put(req, id);
+    public synchronized boolean promotePendingExceptionToActive(int id, ExceptionRequest req) {
+        if (exceptionBreakpointsById.containsKey(id)) {
+            return false;
         }
+        final PendingExceptionBreakpoint pending = pendingExceptionBreakpointsById.remove(id);
+        if (pending == null) {
+            return false;
+        }
+        final ExceptionBreakpointInfo info = new ExceptionBreakpointInfo(pending.getSpec(), req);
+        exceptionBreakpointsById.put(id, info);
+        exceptionInfoByRequest.put(req, info);
+        exceptionIdsByRequest.put(req, id);
+        return true;
     }
 
     /**
@@ -837,10 +865,23 @@ public class BreakpointTracker {
      * Field BPs additionally roll back any partially-created JDI requests if promotion fails
      * mid-flight (a {@code BOTH}-mode entry creates two requests, either of which can throw) and
      * mark the pending entry failed so subsequent cycles do not retry the same orphan-prone path.
+     * <p>
+     * <b>Concurrency:</b> the method is intentionally not {@code synchronized}. Two monitors are
+     * relevant — the tracker monitor (this object) and the {@link JDIConnectionService} monitor.
+     * The pending maps are snapshotted under the tracker monitor here, then each pending entry is
+     * resolved by calling {@link JDIConnectionService#findOrForceLoadClass} <i>without</i> the
+     * tracker monitor held: that call can park inside a target-VM {@code invokeMethod} that only
+     * returns once our event listener drains the resulting events, and the listener takes this
+     * same tracker monitor in {@link #promotePendingFieldsForClass}. The per-entry mutation step
+     * re-acquires the tracker monitor with a recheck that the entry is still pending and that no
+     * other path (listener or a sibling {@link #tryPromotePending} caller) has already promoted
+     * it — the recheck is defense in depth on top of the already-promoted guard inside the
+     * promote* methods themselves. Orphan JDI requests that lose the race are deleted from the
+     * {@link EventRequestManager}.
      *
      * @return number of items promoted in this call
      */
-    public synchronized int tryPromotePending(
+    public int tryPromotePending(
         @Nullable JDIConnectionService jdiService,
         @Nullable ThreadReference preferredThread
     ) {
@@ -860,11 +901,18 @@ public class BreakpointTracker {
             return 0;
         }
 
+        final List<Map.Entry<Integer, PendingBreakpoint>> lineSnapshot;
+        final List<Map.Entry<Integer, PendingExceptionBreakpoint>> exceptionSnapshot;
+        final List<Map.Entry<Integer, PendingFieldBreakpoint>> fieldSnapshot;
+        synchronized (this) {
+            lineSnapshot = new ArrayList<>(pendingBreakpointsById.entrySet());
+            exceptionSnapshot = new ArrayList<>(pendingExceptionBreakpointsById.entrySet());
+            fieldSnapshot = new ArrayList<>(pendingFieldBreakpointsById.entrySet());
+        }
+
         int promoted = 0;
 
-        // Promote pending line breakpoints
-        for (Map.Entry<Integer, PendingBreakpoint> entry :
-            new ArrayList<>(pendingBreakpointsById.entrySet())) {
+        for (Map.Entry<Integer, PendingBreakpoint> entry : lineSnapshot) {
             final int id = entry.getKey();
             final PendingBreakpoint pending = entry.getValue();
             if (pending.getFailureReason() != null) {
@@ -877,19 +925,36 @@ public class BreakpointTracker {
                     continue;
                 }
 
-                final List<Location> locations = refType.locationsOfLine(pending.getLineNumber());
-                if (locations.isEmpty()) {
-                    continue;
-                }
+                synchronized (this) {
+                    // Recheck: the listener path (JdiEventListener.handleClassPrepareEvent) may
+                    // have promoted or removed this entry while we were parked in the JDI invoke.
+                    if (pendingBreakpointsById.get(id) != pending
+                        || pending.getFailureReason() != null
+                        || breakpointsById.containsKey(id)) {
+                        continue;
+                    }
 
-                final BreakpointRequest bp = erm.createBreakpointRequest(locations.get(0));
-                bp.setSuspendPolicy(pending.getSuspendPolicy());
-                bp.enable();
-                disarmIfChained(id, bp);
-                promotePendingToActive(id, bp);
-                promoted++;
-                log.info("[Tracker] Opportunistically promoted pending breakpoint {} for {}:{}",
-                    id, pending.getClassName(), pending.getLineNumber());
+                    final List<Location> locations = refType.locationsOfLine(pending.getLineNumber());
+                    if (locations.isEmpty()) {
+                        continue;
+                    }
+
+                    final BreakpointRequest bp = erm.createBreakpointRequest(locations.get(0));
+                    bp.setSuspendPolicy(pending.getSuspendPolicy());
+                    bp.enable();
+                    disarmIfChained(id, bp);
+                    if (!promotePendingToActive(id, bp)) {
+                        // Defense in depth: the recheck above already short-circuits in the common
+                        // case, but promotePendingToActive is the authoritative guard. If the active
+                        // map gained an entry between the recheck and this call (impossible while we
+                        // hold the monitor, but cheap to assert), tear the orphan request down.
+                        deleteQuietly(erm, bp);
+                        continue;
+                    }
+                    promoted++;
+                    log.info("[Tracker] Opportunistically promoted pending breakpoint {} for {}:{}",
+                        id, pending.getClassName(), pending.getLineNumber());
+                }
             } catch (AbsentInformationException e) {
                 // Class loaded but no debug info — try again later in case a different version arrives
             } catch (Exception e) {
@@ -897,9 +962,7 @@ public class BreakpointTracker {
             }
         }
 
-        // Promote pending exception breakpoints
-        for (Map.Entry<Integer, PendingExceptionBreakpoint> entry :
-            new ArrayList<>(pendingExceptionBreakpointsById.entrySet())) {
+        for (Map.Entry<Integer, PendingExceptionBreakpoint> entry : exceptionSnapshot) {
             final int id = entry.getKey();
             final PendingExceptionBreakpoint pending = entry.getValue();
             if (pending.getFailureReason() != null) {
@@ -912,26 +975,36 @@ public class BreakpointTracker {
                     continue;
                 }
 
-                final ExceptionRequest exReq = erm.createExceptionRequest(
-                    refType, pending.isCaught(), pending.isUncaught());
-                // Always SUSPEND_EVENT_THREAD: even logOnly BPs need a brief suspend so the
-                // listener can read the exception object / evaluate the optional expression.
-                // Auto-resume happens in JdiEventListener.handleExceptionEvent.
-                exReq.setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD);
-                exReq.enable();
-                disarmIfChained(id, exReq);
-                promotePendingExceptionToActive(id, exReq);
-                promoted++;
-                log.info("[Tracker] Opportunistically promoted pending exception breakpoint {} for {}",
-                    id, pending.getExceptionClass());
+                synchronized (this) {
+                    if (pendingExceptionBreakpointsById.get(id) != pending
+                        || pending.getFailureReason() != null
+                        || exceptionBreakpointsById.containsKey(id)) {
+                        continue;
+                    }
+
+                    final ExceptionRequest exReq = erm.createExceptionRequest(
+                        refType, pending.isCaught(), pending.isUncaught());
+                    // Always SUSPEND_EVENT_THREAD: even logOnly BPs need a brief suspend so the
+                    // listener can read the exception object / evaluate the optional expression.
+                    // Auto-resume happens in JdiEventListener.handleExceptionEvent.
+                    exReq.setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD);
+                    exReq.enable();
+                    disarmIfChained(id, exReq);
+                    if (!promotePendingExceptionToActive(id, exReq)) {
+                        // Defense in depth — see the line BP arm above.
+                        deleteQuietly(erm, exReq);
+                        continue;
+                    }
+                    promoted++;
+                    log.info("[Tracker] Opportunistically promoted pending exception breakpoint {} for {}",
+                        id, pending.getExceptionClass());
+                }
             } catch (Exception e) {
                 log.debug("[Tracker] Failed to promote pending exception breakpoint {}: {}", id, e.getMessage());
             }
         }
 
-        // Promote pending field watchpoints
-        for (Map.Entry<Integer, PendingFieldBreakpoint> entry :
-            new ArrayList<>(pendingFieldBreakpointsById.entrySet())) {
+        for (Map.Entry<Integer, PendingFieldBreakpoint> entry : fieldSnapshot) {
             final int id = entry.getKey();
             final PendingFieldBreakpoint pending = entry.getValue();
             if (pending.getFailureReason() != null) {
@@ -943,8 +1016,18 @@ public class BreakpointTracker {
                 if (refType == null) {
                     continue;
                 }
-                if (promoteSinglePendingField(id, pending, refType, vm, erm, jdiService)) {
-                    promoted++;
+                // promoteSinglePendingField mutates state and is shared with the listener-side
+                // path; the synchronized block below makes the recheck + creation + map mutation
+                // atomic so a concurrent promotePendingFieldsForClass cannot wedge a duplicate
+                // watchpoint onto the target VM.
+                synchronized (this) {
+                    if (pendingFieldBreakpointsById.get(id) != pending
+                        || pending.getFailureReason() != null) {
+                        continue;
+                    }
+                    if (promoteSinglePendingField(id, pending, refType, vm, erm, jdiService)) {
+                        promoted++;
+                    }
                 }
             } catch (Exception e) {
                 log.debug("[Tracker] Failed to promote pending field BP {}: {}", id, e.getMessage());
@@ -1548,9 +1631,10 @@ public class BreakpointTracker {
      * {@link #getLastBreakpoint()} or the latest {@link EventHistory} entry based on the
      * returned value.
      * <p>
-     * Used by {@link JDWPTools#jdwp_resume_until_event(Integer)} to avoid the
-     * "step fired → no waiter armed → resume_until_event overshoots" race documented in
-     * P0-2/P0-3.
+     * Used by {@link JDWPTools#jdwp_resume_until_event(Integer)} to close the
+     * "event fires between two tool calls → no waiter armed yet → next resume_until_event
+     * overshoots the just-suspended thread" window: the flag is set unconditionally by
+     * {@link #fireNextEvent} so a late waiter sees the event without re-resuming the VM.
      */
     public synchronized boolean consumePendingFire() {
         if (pendingFire) {
@@ -1575,9 +1659,9 @@ public class BreakpointTracker {
     /**
      * Classifies the JDI event behind a {@link LastBreakpoint} snapshot so the renderer can
      * distinguish "thread is parked because BP #N fired" from "thread is parked because a step
-     * landed" or "…because an exception was thrown". Prior to F-RA2 every snapshot was implicitly
-     * {@link #BREAKPOINT} and a {@link #STEP} landing leaked the *previous* BP id into the
-     * "Event fired" line as a stale {@code breakpoint=N}.
+     * landed" or "…because an exception was thrown". Without this discriminator a {@link #STEP}
+     * landing would inherit and re-render the previous {@code breakpoint=N} from the prior
+     * snapshot, misleading the user about why the thread is parked.
      */
     public enum EventKind {
         /** A line / field / conditional breakpoint hit. */

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/BreakpointTracker.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/BreakpointTracker.java
@@ -31,19 +31,34 @@ import java.util.concurrent.atomic.AtomicInteger;
  * normal path) or by the {@link #tryPromotePending} safety net (called from {@link JDIConnectionService#getVM()}
  * before every tool call) for classes loaded before any debugger event was delivered.
  * <p>
- * <b>Thread-safety:</b> public mutators that touch state in a single critical section are
- * {@code synchronized} on this tracker. {@link #tryPromotePending} is the exception: it cannot
- * hold the tracker monitor across {@link JDIConnectionService#findOrForceLoadClass}, because that
- * call parks the worker inside a target-VM {@code invokeMethod} until the JDI event listener drains
- * the resulting events — and the listener itself takes this monitor in
- * {@link #promotePendingFieldsForClass}. So {@code tryPromotePending} snapshots the pending maps
- * under the monitor, releases it across each per-entry force-load round-trip, then re-acquires it
- * for a recheck-and-mutate critical section. The promote* methods are the authoritative
- * already-promoted guard; losers in that race tear down their orphan JDI request.
- * <p>
- * The read-mostly state maps are {@code ConcurrentHashMap} so listeners can iterate without
- * contending with mutators. The {@code lastBreakpoint*} fields are {@code volatile} for cross-thread
- * visibility from the JDI listener thread to MCP worker threads.
+ * <b>Thread-safety:</b> the contract is layered, not uniform — readers should not assume "every
+ * public mutator is {@code synchronized}". The actual rules:
+ * <ul>
+ *   <li>The state maps are {@link ConcurrentHashMap}, so single-map mutations
+ *       ({@code registerBreakpoint}, {@code unregisterByRequest}, {@code markPendingFailed},
+ *       {@code registerClassPrepareRequest}, {@code setCondition}, {@code setLogpointExpression},
+ *       {@code registerExceptionBreakpoint}, {@code registerFieldBreakpoint},
+ *       {@code promotePendingFieldToActive}, …) rely on the map's own atomicity and are
+ *       intentionally not {@code synchronized}.</li>
+ *   <li>{@code synchronized} on this tracker guards operations that must mutate <i>multiple maps
+ *       atomically</i> — promotion (remove from pending + insert into active + index the request),
+ *       removal that spans both maps, {@code clearAll}, and the pending-side registrations whose
+ *       atomicity matters for {@link #tryPromotePending}'s recheck-and-mutate critical section.</li>
+ *   <li>{@link #tryPromotePending} is the documented exception to the "single critical section"
+ *       pattern: it cannot hold the tracker monitor across
+ *       {@link JDIConnectionService#findOrForceLoadClass}, because that call parks the worker
+ *       inside a target-VM {@code invokeMethod} until the JDI event listener drains the resulting
+ *       events — and the listener itself takes this monitor in
+ *       {@link #promotePendingFieldsForClass}. So {@code tryPromotePending} snapshots the pending
+ *       maps under the monitor, releases it across each per-entry force-load round-trip, then
+ *       re-acquires it for a recheck-and-mutate critical section. The {@code promote*} methods
+ *       are the authoritative already-promoted guard; losers in that race tear down their orphan
+ *       JDI request.</li>
+ *   <li>The {@code lastBreakpoint*} fields are {@code volatile} for cross-thread visibility from
+ *       the JDI listener thread to MCP worker threads.</li>
+ * </ul>
+ * When adding new public mutators, decide consciously which bucket they fall into — a method that
+ * touches more than one map atomically must take the monitor; a single-map mutation should not.
  */
 @Service
 public class BreakpointTracker {

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/BreakpointTracker.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/BreakpointTracker.java
@@ -431,16 +431,21 @@ public class BreakpointTracker {
     /**
      * Promote a pending breakpoint to active: remove from pending, add to active with the same ID.
      * Returns {@code true} if the promotion happened. Returns {@code false} when the synthetic id
-     * already has an active entry — the listener path and the {@link #tryPromotePending} safety net
-     * race for the same pending entries, and the second arrival must not overwrite the winner.
-     * Callers that receive {@code false} are responsible for tearing down the now-orphan
-     * {@link BreakpointRequest} they just created (via {@code erm.deleteEventRequest(bp)}).
+     * already has an active entry (the listener path and the {@link #tryPromotePending} safety net
+     * race for the same pending entries, and the second arrival must not overwrite the winner) or
+     * when the pending entry has already been consumed — e.g. the user cleared it between the
+     * class-prepare snapshot and this call. Callers that receive {@code false} are responsible for
+     * tearing down the now-orphan {@link BreakpointRequest} they just created
+     * (via {@code erm.deleteEventRequest(bp)}).
      */
     public synchronized boolean promotePendingToActive(int id, BreakpointRequest bp) {
         if (breakpointsById.containsKey(id)) {
             return false;
         }
-        pendingBreakpointsById.remove(id);
+        final PendingBreakpoint pending = pendingBreakpointsById.remove(id);
+        if (pending == null) {
+            return false;
+        }
         breakpointsById.put(id, bp);
         breakpointIdsByRequest.put(bp, id);
         return true;

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JDIConnectionService.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JDIConnectionService.java
@@ -463,25 +463,41 @@ public class JDIConnectionService {
     /**
      * Returns the connected VirtualMachine, auto-reconnecting if the connection has dropped.
      *
+     * <p><b>Concurrency:</b> the connect / auto-reconnect work runs under the service monitor (so
+     * a concurrent {@code disconnect()} cannot race with an in-flight reconnect), but the
+     * opportunistic pending-breakpoint retry runs <i>outside</i> the monitor. The retry path may
+     * park inside a JDI {@code invokeMethod} (force-loading a deferred class), which can only
+     * complete once our event listener drains the resulting events; holding this monitor across
+     * that round-trip would block every other {@code getVM()} caller — and thus every other MCP
+     * tool call — for the duration of the invoke.
+     *
      * @return the live {@link VirtualMachine} instance
      * @throws Exception if not connected and reconnection fails
      */
-    public synchronized VirtualMachine getVM() throws Exception {
-        ensureConnected();
+    public VirtualMachine getVM() throws Exception {
+        final VirtualMachine current;
+        synchronized (this) {
+            ensureConnected();
+            current = vm;
+        }
         // Opportunistic pending-breakpoint retry — handles bootstrap classes whose ClassPrepareEvent
-        // is never delivered. Best-effort; failures are swallowed.
+        // is never delivered. Best-effort; failures are swallowed. Runs outside the service monitor
+        // (see class-level Javadoc for the rationale).
         try {
             breakpointTracker.tryPromotePending(this, null);
         } catch (Exception e) {
             log.debug("[JDI] Pending promotion failed: {}", e.getMessage());
         }
-        return Objects.requireNonNull(vm);
+        return Objects.requireNonNull(current);
     }
 
     /**
      * Returns the raw VM reference without triggering opportunistic promotion. Used by
      * {@link BreakpointTracker#tryPromotePending(JDIConnectionService, ThreadReference)} to avoid
-     * recursion. Callers must already hold the connection service monitor.
+     * recursion. Reads the {@code vm} field directly without taking the service monitor — the
+     * field is written under the monitor and read here as a plain reference; a stale read returns
+     * a recently-disposed {@link VirtualMachine} whose JDI calls throw {@link com.sun.jdi.VMDisconnectedException},
+     * which the caller already handles.
      */
     @Nullable
     VirtualMachine getRawVM() {
@@ -991,76 +1007,101 @@ public class JDIConnectionService {
     }
 
     /**
-     * Locates a class in the target VM, force-loading it via {@code Class.forName(name)} if not
-     * yet visible. The force-load attempt requires a suspended thread (typically the main thread
-     * paused at VMStart, or any thread suspended at a breakpoint). Returns null if the class
-     * cannot be found or force-loaded.
+     * Convenience overload that lets the implementation pick the force-load thread. Prefer the
+     * two-arg form when a known-good thread is already in hand (e.g. the current breakpoint
+     * thread); it avoids a fallback scan of {@code allThreads()}.
      *
-     * <p>This solves the bootstrap-class problem: classes like {@code java.lang.IllegalStateException}
-     * are not visible to {@link VirtualMachine#classesByName(String)} until first referenced, and
-     * their {@link com.sun.jdi.event.ClassPrepareEvent} is not delivered to JDI clients. Forcing
-     * the load via {@code Class.forName} bypasses both issues.
+     * @see #findOrForceLoadClass(String, ThreadReference)
      */
     @Nullable
-    public synchronized ReferenceType findOrForceLoadClass(String className) {
+    public ReferenceType findOrForceLoadClass(String className) {
         return findOrForceLoadClass(className, null);
     }
 
     /**
-     * Same as {@link #findOrForceLoadClass(String)} but allows passing a preferred thread for the
-     * force-load step. This must be a thread that is suspended at a JDI method-invocation event
+     * Locates a class in the target VM, force-loading it via {@code Class.forName(name)} if not yet
+     * visible. Solves the bootstrap-class problem: classes like {@code java.lang.IllegalStateException}
+     * are not visible to {@link VirtualMachine#classesByName} until first referenced, and their
+     * {@link com.sun.jdi.event.ClassPrepareEvent} is not delivered to JDI clients. Returns
+     * {@code null} if the class cannot be found or force-loaded.
+     *
+     * <p>{@code preferredThread}, if non-null, must be suspended at a JDI method-invocation event
      * (breakpoint, step, exception, class prepare) — JDI cannot invoke methods on threads
-     * suspended via vm.suspend() (e.g., the VMStart-suspended state).
+     * suspended via {@code vm.suspend()} (e.g., the VMStart-suspended state). If unusable or
+     * {@code null}, the method falls back to {@link #findSuspendedThread}.
+     *
+     * <p><b>Concurrency:</b> the method is intentionally not {@code synchronized}. Phase 1 (cheap
+     * lookups via {@link VirtualMachine#classesByName} and the {@code allClasses()} fallback, plus
+     * pre-invoke preparation) runs under the {@code JDIConnectionService} monitor and captures a
+     * local {@code vmRef}. Phase 2 ({@code ClassType.invokeMethod} into the target VM) runs
+     * <i>outside</i> the monitor because it can only complete once our JDI event listener drains
+     * the events produced by running {@code <clinit>}. Holding this monitor across the invoke would
+     * re-introduce the deferred-class-load deadlock that {@link BreakpointTracker#tryPromotePending}
+     * also avoids — any listener path that touches the {@code JDIConnectionService} monitor would
+     * block on a worker parked here. Phase 3 (post-invoke {@code classesByName} lookup) reuses the
+     * captured {@code vmRef} rather than re-reading {@code this.vm}: a concurrent {@code disconnect}
+     * may have nulled the field, and a {@link com.sun.jdi.VMDisconnectedException} from the disposed
+     * reference is already handled here, whereas a {@code null} re-read would silently discard a
+     * successful force-load.
      */
     @Nullable
-    public synchronized ReferenceType findOrForceLoadClass(String className, @Nullable ThreadReference preferredThread) {
-        if (vm == null) {
-            return null;
-        }
+    public ReferenceType findOrForceLoadClass(String className, @Nullable ThreadReference preferredThread) {
+        // Phase 1: cheap lookups + force-load preflight, all under the monitor.
+        final VirtualMachine vmRef;
+        final ThreadReference thread;
+        final ClassType classClass;
+        final Method forName;
+        final StringReference nameRef;
+        synchronized (this) {
+            if (vm == null) {
+                return null;
+            }
+            vmRef = vm;
 
-        // Fast path: already visible via the indexed lookup
-        final List<ReferenceType> existing = vm.classesByName(className);
-        if (!existing.isEmpty()) {
-            return existing.get(0);
-        }
+            // Fast path: already visible via the indexed lookup
+            final List<ReferenceType> existing = vmRef.classesByName(className);
+            if (!existing.isEmpty()) {
+                return existing.get(0);
+            }
 
-        // Fallback 1: full scan of allClasses() — sometimes bootstrap classes appear here
-        // even when classesByName misses them.
-        final ReferenceType scanned = vm.allClasses().stream()
-            .filter(rt -> rt.name().equals(className))
-            .findFirst()
-            .orElse(null);
-        if (scanned != null) {
-            log.info("[JDI] Found '{}' via allClasses() scan (not in classesByName index)", className);
-            return scanned;
-        }
+            // Fallback 1: full scan of allClasses() — sometimes bootstrap classes appear here
+            // even when classesByName misses them.
+            final ReferenceType scanned = vmRef.allClasses().stream()
+                .filter(rt -> rt.name().equals(className))
+                .findFirst()
+                .orElse(null);
+            if (scanned != null) {
+                log.info("[JDI] Found '{}' via allClasses() scan (not in classesByName index)", className);
+                return scanned;
+            }
 
-        // Fallback 2: invoke Class.forName(name) in the target VM to force a load.
-        // JDI requires the thread to be suspended at a method-invocation event AND have frames.
-        final ThreadReference thread = preferredThread != null && isUsableForInvoke(preferredThread)
-            ? preferredThread : findSuspendedThread();
-        if (thread == null) {
-            log.debug("[JDI] Cannot force-load '{}' — no thread suspended at a method-invocation event", className);
-            return null;
-        }
+            // Fallback 2: invoke Class.forName(name) in the target VM to force a load.
+            // JDI requires the thread to be suspended at a method-invocation event AND have frames.
+            thread = preferredThread != null && isUsableForInvoke(preferredThread)
+                ? preferredThread : findSuspendedThread();
+            if (thread == null) {
+                log.debug("[JDI] Cannot force-load '{}' — no thread suspended at a method-invocation event", className);
+                return null;
+            }
 
-        try {
-            log.info("[JDI] Attempting to force-load '{}' via thread '{}' (suspended={}, frames={})",
-                className, thread.name(), thread.isSuspended(), tryFrameCount(thread));
-
-            final List<ReferenceType> classClassList = vm.classesByName("java.lang.Class");
+            final List<ReferenceType> classClassList = vmRef.classesByName("java.lang.Class");
             if (classClassList.isEmpty()) {
                 log.warn("[JDI] java.lang.Class not visible in target VM — cannot force-load");
                 return null;
             }
-            final ClassType classClass = (ClassType) classClassList.get(0);
-            final Method forName = classClass.concreteMethodByName("forName", "(Ljava/lang/String;)Ljava/lang/Class;");
+            classClass = (ClassType) classClassList.get(0);
+            forName = classClass.concreteMethodByName("forName", "(Ljava/lang/String;)Ljava/lang/Class;");
             if (forName == null) {
                 log.warn("[JDI] Class.forName(String) method not found");
                 return null;
             }
+            nameRef = vmRef.mirrorOf(className);
+        }
 
-            final StringReference nameRef = vm.mirrorOf(className);
+        // Phase 2: invokeMethod OUTSIDE the monitor.
+        try {
+            log.info("[JDI] Attempting to force-load '{}' via thread '{}' (suspended={}, frames={})",
+                className, thread.name(), thread.isSuspended(), tryFrameCount(thread));
             // Reentrancy guard: forcing Class.forName runs the target class's <clinit>, which
             // may hit a user breakpoint. Without the guard the listener would re-suspend the
             // thread we are driving and the outer invokeMethod would hang. Capture the id up
@@ -1073,12 +1114,22 @@ public class JDIConnectionService {
                 evaluationGuard.exit(guardedThreadId);
             }
             log.info("[JDI] Force-loaded class '{}' via Class.forName", className);
-
-            final List<ReferenceType> retry = vm.classesByName(className);
-            return retry.isEmpty() ? null : retry.get(0);
         } catch (Exception e) {
             log.warn("[JDI] Could not force-load class '{}': {} ({})",
                 className, e.getMessage(), e.getClass().getSimpleName());
+            return null;
+        }
+
+        // Phase 3: post-invoke lookup. Use the VM reference captured in Phase 1 rather than
+        // re-reading `this.vm`: a concurrent disconnect can null out the field even though our
+        // forceLoad just succeeded against the captured instance, and that disposed reference will
+        // throw VMDisconnectedException from any JDI call — already handled by the surrounding
+        // try/catch chain. Re-reading `this.vm` would silently discard a successful force-load.
+        try {
+            final List<ReferenceType> afterForceLoad = vmRef.classesByName(className);
+            return afterForceLoad.isEmpty() ? null : afterForceLoad.get(0);
+        } catch (Exception e) {
+            log.debug("[JDI] Phase 3 lookup for '{}' failed after force-load: {}", className, e.getMessage());
             return null;
         }
     }

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JDWPTools.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JDWPTools.java
@@ -1883,8 +1883,15 @@ public class JDWPTools {
                         // registered could fire once unchained on a hot code path.
                         final BreakpointRequest bpRequest = erm.createBreakpointRequest(locations.get(0));
                         bpRequest.setSuspendPolicy(jdiPolicy);
-                        breakpointTracker.promotePendingToActive(pendingId, bpRequest);
-                        if (triggerBreakpointId == null) {
+                        if (!breakpointTracker.promotePendingToActive(pendingId, bpRequest)) {
+                            // Another path (listener or safety-net) won the promotion race; tear
+                            // down the loser request so no duplicate fires on the target VM.
+                            try {
+                                erm.deleteEventRequest(bpRequest);
+                            } catch (Exception ignored) {
+                                // VM may already be disconnected — best-effort cleanup.
+                            }
+                        } else if (triggerBreakpointId == null) {
                             bpRequest.setEnabled(true);
                         }
                         return String.format("Breakpoint set at %s:%d (ID: %d, suspend: %s%s%s)",
@@ -1980,7 +1987,15 @@ public class JDWPTools {
                         final BreakpointRequest bpRequest = erm.createBreakpointRequest(locations.get(0));
                         bpRequest.setSuspendPolicy(jdiPolicy);
                         bpRequest.enable();
-                        breakpointTracker.promotePendingToActive(pendingId, bpRequest);
+                        if (!breakpointTracker.promotePendingToActive(pendingId, bpRequest)) {
+                            // Another path (listener or safety-net) won the promotion race; tear
+                            // down the loser request so no duplicate fires on the target VM.
+                            try {
+                                erm.deleteEventRequest(bpRequest);
+                            } catch (Exception ignored) {
+                                // VM may already be disconnected — best-effort cleanup.
+                            }
+                        }
                         return String.format("Logpoint set at %s:%d (ID: %d, expression: %s%s)",
                             className, lineNumber, pendingId, expression, conditionInfo);
                     }

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JdiEventListener.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JdiEventListener.java
@@ -1018,7 +1018,19 @@ public class JdiEventListener {
                     // otherwise the very first event could fire before the trigger ever has.
                     breakpointTracker.disarmIfChained(id, bpRequest);
 
-                    breakpointTracker.promotePendingToActive(id, bpRequest);
+                    if (!breakpointTracker.promotePendingToActive(id, bpRequest)) {
+                        // The opportunistic safety net in BreakpointTracker.tryPromotePending won
+                        // the race and bound a different BreakpointRequest under this synthetic id.
+                        // Tear down the loser before it can fire — otherwise a duplicate event
+                        // would arrive on the target VM with no tracker entry pointing at it.
+                        try {
+                            erm.deleteEventRequest(bpRequest);
+                        } catch (Exception ignored) {
+                            // VM may already be disconnected — best-effort cleanup.
+                        }
+                        log.debug("[JDI] Deferred breakpoint {} promotion lost the race to the opportunistic path; orphan request deleted", id);
+                        continue;
+                    }
                     log.info("[JDI] Deferred breakpoint {} activated at {}:{}", id, className, pending.getLineNumber());
 
                 } catch (AbsentInformationException e) {
@@ -1040,7 +1052,17 @@ public class JdiEventListener {
                     exReq.setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD);
                     exReq.enable();
                     breakpointTracker.disarmIfChained(id, exReq);
-                    breakpointTracker.promotePendingExceptionToActive(id, exReq);
+                    if (!breakpointTracker.promotePendingExceptionToActive(id, exReq)) {
+                        // Lost the race against tryPromotePending — see the line BP arm above for
+                        // the full rationale. Tear down the orphan request so it cannot fire.
+                        try {
+                            erm.deleteEventRequest(exReq);
+                        } catch (Exception ignored) {
+                            // VM may already be disconnected — best-effort cleanup.
+                        }
+                        log.debug("[JDI] Deferred exception breakpoint {} promotion lost the race to the opportunistic path; orphan request deleted", id);
+                        continue;
+                    }
                     log.info("[JDI] Deferred exception breakpoint {} activated for {}", id, className);
                 } catch (Exception e) {
                     breakpointTracker.markPendingExceptionFailed(id, e.getMessage());

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/ClasspathDiscoverer.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/ClasspathDiscoverer.java
@@ -25,8 +25,8 @@ import java.util.*;
  * 3. Tomcat `WebappClassLoaderBase` instances detected the same way.
  * <p>
  * Discovery aborts with {@link JdkDiscoveryService.JdkNotFoundException} if no local JDK matching
- * the target version is found via {@link JdkDiscoveryService} — JDT requires `--system <jdkPath>`
- * to compile against the target's system classes.
+ * the target version is found via {@link JdkDiscoveryService} — JDT requires
+ * {@code --system <jdkPath>} to compile against the target's system classes.
  */
 public class ClasspathDiscoverer {
 

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/InMemoryJavaCompiler.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/InMemoryJavaCompiler.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
  * `javax.tools.JavaFileObject` backed by a path. The temp directory is unconditionally deleted in `finally`.
  * <p>
  * Requires {@link #configure(String, String, int)} to be called first with the path to a target-matching JDK
- * (used as `--system <jdkPath>` so JDT can resolve `java.*` system classes) and the target VM's classpath.
+ * (used as {@code --system <jdkPath>} so JDT can resolve {@code java.*} system classes) and the target VM's classpath.
  * Calling {@link #compile(String, String)} without configuration throws {@link JdiEvaluationException}.
  * <p>
  * Source/target version is derived from the major version: `1.8` for Java 8, the bare number for Java 9+.

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdkDiscoveryService.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdkDiscoveryService.java
@@ -15,22 +15,22 @@ import java.util.stream.Stream;
 
 /**
  * Discovers a local JDK installation matching the target JVM's Java version. The Eclipse JDT
- * compiler used by {@link InMemoryJavaCompiler} needs `--system <jdkPath>` to resolve `java.*`
- * system classes when compiling expression-evaluator wrapper classes; without this discovery the
- * compiler can't produce bytecode for the target.
+ * compiler used by {@link InMemoryJavaCompiler} needs {@code --system <jdkPath>} to resolve
+ * {@code java.*} system classes when compiling expression-evaluator wrapper classes; without this
+ * discovery the compiler can't produce bytecode for the target.
  * <p>
  * One-shot, stateful helper: holds {@link #targetMajorVersion} after a successful
  * {@link #discoverMatchingJdk} so callers can read it without re-running discovery. NOT a Spring
  * bean — instantiated manually by {@link ClasspathDiscoverer} per discovery call.
  * <p>
  * Search strategy (in order):
- * 1. The target JVM's own `java.home` if accessible from the MCP server's filesystem.
- * 2. The `JAVA_HOME` environment variable, but only when its `<jdkHome>/release` file confirms
- * a matching major version (a mismatched JAVA_HOME would later trigger cryptic JDT class-file
+ * 1. The target JVM's own {@code java.home} if accessible from the MCP server's filesystem.
+ * 2. The {@code JAVA_HOME} environment variable, but only when its {@code <jdkHome>/release} file
+ * confirms a matching major version (a mismatched JAVA_HOME would later trigger cryptic JDT class-file
  * errors).
- * 3. Common per-OS install paths (Adoptium, Oracle, OpenJDK, Zulu on Windows; `/usr/lib/jvm`,
- * `/opt`, SDKMAN under `~/.sdkman/candidates/java` on Linux/macOS).
- * 4. Directory scan of those parent paths for any subdirectory matching a `<name>-<version>`
+ * 3. Common per-OS install paths (Adoptium, Oracle, OpenJDK, Zulu on Windows; {@code /usr/lib/jvm},
+ * {@code /opt}, SDKMAN under {@code ~/.sdkman/candidates/java} on Linux/macOS).
+ * 4. Directory scan of those parent paths for any subdirectory matching a {@code <name>-<version>}
  * pattern containing the major version.
  */
 public class JdkDiscoveryService {
@@ -106,7 +106,7 @@ public class JdkDiscoveryService {
     }
 
     /**
-     * Reads {@code JAVA_VERSION="…"} from the `<jdkHome>/release` file (Java 9+ ships it
+     * Reads {@code JAVA_VERSION="…"} from the {@code <jdkHome>/release} file (Java 9+ ships it
      * unconditionally) and returns the parsed major version. Returns 0 if the file is missing
      * or malformed — callers should treat that as "version unknown, don't use".
      */

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerExceptionAndMetadataTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerExceptionAndMetadataTest.java
@@ -1,5 +1,6 @@
 package one.edee.mcp.jdwp;
 
+import com.sun.jdi.AbsentInformationException;
 import com.sun.jdi.Location;
 import com.sun.jdi.ReferenceType;
 import com.sun.jdi.VirtualMachine;
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -586,6 +588,350 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			assertThat(promoted).isEqualTo(1);
 			// enable() is called (from the production code itself), but setEnabled(false) must NOT.
 			verify(bp, org.mockito.Mockito.never()).setEnabled(false);
+		}
+	}
+
+	/**
+	 * Recheck-race coverage for the {@code tryPromotePending} per-entry recheck branches. The
+	 * worker thread snapshots pending entries under the tracker monitor, releases the monitor for
+	 * the (potentially slow) {@code findOrForceLoadClass} JDI hop, then re-acquires the monitor to
+	 * recheck-then-promote each entry. Three things can have changed during the JDI hop:
+	 * <ul>
+	 *   <li>another thread removed the pending entry (e.g. user issued {@code jdwp_clear})</li>
+	 *   <li>another thread marked the pending entry failed (e.g. listener path classifier)</li>
+	 *   <li>the listener path already promoted the entry from the {@code ClassPrepareEvent} side</li>
+	 * </ul>
+	 * In all three cases the worker's per-entry recheck must short-circuit so it neither double-
+	 * registers a JDI request nor counts the entry as freshly promoted.
+	 */
+	@Nested
+	@DisplayName("tryPromotePending per-entry recheck races")
+	class PromotePendingRecheckRaces {
+
+		@Test
+		void shouldReturnZeroAndSkipEntryWhenPendingLineBpIsRemovedWhileWorkerIsResolvingClass() throws Exception {
+			JDIConnectionService service = mock(JDIConnectionService.class);
+			VirtualMachine vm = mock(VirtualMachine.class);
+			EventRequestManager erm = mock(EventRequestManager.class);
+			ReferenceType refType = mock(ReferenceType.class);
+			when(service.getRawVM()).thenReturn(vm);
+			when(vm.eventRequestManager()).thenReturn(erm);
+
+			int pendingId = tracker.registerPendingBreakpoint("com.example.Foo", 42, 2, "ALL");
+
+			// While the worker is parked inside findOrForceLoadClass, another caller removes the
+			// pending entry. The recheck must observe pendingBreakpointsById.get(id) != pending and
+			// continue without ever calling locationsOfLine / createBreakpointRequest.
+			when(service.findOrForceLoadClass(eq("com.example.Foo"), any()))
+				.thenAnswer(inv -> {
+					tracker.removePendingBreakpoint(pendingId);
+					return refType;
+				});
+
+			int promoted = tracker.tryPromotePending(service, null);
+
+			assertThat(promoted).isZero();
+			assertThat(tracker.getPendingBreakpoint(pendingId)).isNull();
+			assertThat(tracker.getBreakpoint(pendingId)).isNull();
+			org.mockito.Mockito.verify(refType, org.mockito.Mockito.never()).locationsOfLine(org.mockito.ArgumentMatchers.anyInt());
+		}
+
+		@Test
+		void shouldReturnZeroAndSkipEntryWhenPendingLineBpIsMarkedFailedWhileWorkerIsResolvingClass() throws Exception {
+			JDIConnectionService service = mock(JDIConnectionService.class);
+			VirtualMachine vm = mock(VirtualMachine.class);
+			EventRequestManager erm = mock(EventRequestManager.class);
+			ReferenceType refType = mock(ReferenceType.class);
+			when(service.getRawVM()).thenReturn(vm);
+			when(vm.eventRequestManager()).thenReturn(erm);
+
+			int pendingId = tracker.registerPendingBreakpoint("com.example.Foo", 42, 2, "ALL");
+
+			when(service.findOrForceLoadClass(eq("com.example.Foo"), any()))
+				.thenAnswer(inv -> {
+					tracker.markPendingFailed(pendingId, "concurrent classifier marked failed");
+					return refType;
+				});
+
+			int promoted = tracker.tryPromotePending(service, null);
+
+			assertThat(promoted).isZero();
+			// Entry stays in the pending map so the failure reason is visible to overview tools.
+			assertThat(tracker.getPendingBreakpoint(pendingId)).isNotNull();
+			assertThat(tracker.getPendingBreakpoint(pendingId).getFailureReason())
+				.isEqualTo("concurrent classifier marked failed");
+			org.mockito.Mockito.verify(refType, org.mockito.Mockito.never()).locationsOfLine(org.mockito.ArgumentMatchers.anyInt());
+		}
+
+		@Test
+		void shouldReturnZeroForLineBpWhenAnotherCallerHasPromotedItToActiveWhileWorkerIsResolvingClass() throws Exception {
+			JDIConnectionService service = mock(JDIConnectionService.class);
+			VirtualMachine vm = mock(VirtualMachine.class);
+			EventRequestManager erm = mock(EventRequestManager.class);
+			ReferenceType refType = mock(ReferenceType.class);
+			BreakpointRequest listenerBp = mock(BreakpointRequest.class, "listenerBp");
+			when(service.getRawVM()).thenReturn(vm);
+			when(vm.eventRequestManager()).thenReturn(erm);
+
+			int pendingId = tracker.registerPendingBreakpoint("com.example.Foo", 42, 2, "ALL");
+
+			// While the worker is parked, the listener path promotes the same id to active using its
+			// own BreakpointRequest. The worker's recheck must observe breakpointsById.containsKey(id)
+			// and skip the entry — otherwise it would overwrite breakpointsById with its own BP and
+			// leave listenerBp armed on the target VM as a ghost without tracker entry.
+			when(service.findOrForceLoadClass(eq("com.example.Foo"), any()))
+				.thenAnswer(inv -> {
+					tracker.promotePendingToActive(pendingId, listenerBp);
+					return refType;
+				});
+
+			int promoted = tracker.tryPromotePending(service, null);
+
+			assertThat(promoted).isZero();
+			assertThat(tracker.getBreakpoint(pendingId))
+				.as("the listener-side BP must remain bound to the synthetic id")
+				.isSameAs(listenerBp);
+			org.mockito.Mockito.verify(refType, org.mockito.Mockito.never()).locationsOfLine(org.mockito.ArgumentMatchers.anyInt());
+		}
+
+		@Test
+		void shouldReturnZeroAndSkipEntryWhenPendingExceptionBpIsRemovedWhileWorkerIsResolvingClass() throws Exception {
+			JDIConnectionService service = mock(JDIConnectionService.class);
+			VirtualMachine vm = mock(VirtualMachine.class);
+			EventRequestManager erm = mock(EventRequestManager.class);
+			ReferenceType refType = mock(ReferenceType.class);
+			when(service.getRawVM()).thenReturn(vm);
+			when(vm.eventRequestManager()).thenReturn(erm);
+
+			int pendingId = tracker.registerPendingExceptionBreakpoint(
+				ExceptionBreakpointSpec.suspending("com.example.MyException", true, true));
+
+			when(service.findOrForceLoadClass(eq("com.example.MyException"), any()))
+				.thenAnswer(inv -> {
+					tracker.removeExceptionBreakpoint(pendingId);
+					return refType;
+				});
+
+			int promoted = tracker.tryPromotePending(service, null);
+
+			assertThat(promoted).isZero();
+			assertThat(tracker.getAllPendingExceptionBreakpoints()).doesNotContainKey(pendingId);
+			assertThat(tracker.getAllExceptionBreakpoints()).doesNotContainKey(pendingId);
+			org.mockito.Mockito.verify(erm, org.mockito.Mockito.never())
+				.createExceptionRequest(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyBoolean(), org.mockito.ArgumentMatchers.anyBoolean());
+		}
+
+		@Test
+		void shouldReturnZeroAndSkipEntryWhenPendingExceptionBpIsMarkedFailedWhileWorkerIsResolvingClass() throws Exception {
+			JDIConnectionService service = mock(JDIConnectionService.class);
+			VirtualMachine vm = mock(VirtualMachine.class);
+			EventRequestManager erm = mock(EventRequestManager.class);
+			ReferenceType refType = mock(ReferenceType.class);
+			when(service.getRawVM()).thenReturn(vm);
+			when(vm.eventRequestManager()).thenReturn(erm);
+
+			int pendingId = tracker.registerPendingExceptionBreakpoint(
+				ExceptionBreakpointSpec.suspending("com.example.MyException", true, true));
+
+			when(service.findOrForceLoadClass(eq("com.example.MyException"), any()))
+				.thenAnswer(inv -> {
+					tracker.markPendingExceptionFailed(pendingId, "concurrent classifier marked failed");
+					return refType;
+				});
+
+			int promoted = tracker.tryPromotePending(service, null);
+
+			assertThat(promoted).isZero();
+			assertThat(tracker.getAllPendingExceptionBreakpoints().get(pendingId).getFailureReason())
+				.isEqualTo("concurrent classifier marked failed");
+			org.mockito.Mockito.verify(erm, org.mockito.Mockito.never())
+				.createExceptionRequest(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyBoolean(), org.mockito.ArgumentMatchers.anyBoolean());
+		}
+
+		@Test
+		void shouldReturnZeroForExceptionBpWhenAnotherCallerHasPromotedItToActiveWhileWorkerIsResolvingClass() throws Exception {
+			JDIConnectionService service = mock(JDIConnectionService.class);
+			VirtualMachine vm = mock(VirtualMachine.class);
+			EventRequestManager erm = mock(EventRequestManager.class);
+			ReferenceType refType = mock(ReferenceType.class);
+			ExceptionRequest listenerExReq = mock(ExceptionRequest.class, "listenerExReq");
+			when(service.getRawVM()).thenReturn(vm);
+			when(vm.eventRequestManager()).thenReturn(erm);
+
+			int pendingId = tracker.registerPendingExceptionBreakpoint(
+				ExceptionBreakpointSpec.suspending("com.example.MyException", true, true));
+
+			when(service.findOrForceLoadClass(eq("com.example.MyException"), any()))
+				.thenAnswer(inv -> {
+					tracker.promotePendingExceptionToActive(pendingId, listenerExReq);
+					return refType;
+				});
+
+			int promoted = tracker.tryPromotePending(service, null);
+
+			assertThat(promoted).isZero();
+			assertThat(tracker.getAllExceptionBreakpoints().get(pendingId).getRequest())
+				.as("the listener-side ExceptionRequest must remain bound to the synthetic id")
+				.isSameAs(listenerExReq);
+			org.mockito.Mockito.verify(erm, org.mockito.Mockito.never())
+				.createExceptionRequest(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyBoolean(), org.mockito.ArgumentMatchers.anyBoolean());
+		}
+
+		/**
+		 * Coverage for the {@link AbsentInformationException} branch in the line-BP arm of
+		 * {@link BreakpointTracker#tryPromotePending}: when the class is loaded but carries no
+		 * debug info (or carries it for a different version of the source), {@code locationsOfLine}
+		 * throws {@code AbsentInformationException}. The arm must swallow the exception so a single
+		 * info-less class does not abort promotion of other pending entries, and must leave the
+		 * pending entry in place so a later retry — perhaps after a different version of the class
+		 * loads — gets another chance.
+		 */
+		@Test
+		void shouldSkipLineBpWhenLocationsOfLineThrowsAbsentInformationException() throws Exception {
+			JDIConnectionService service = mock(JDIConnectionService.class);
+			VirtualMachine vm = mock(VirtualMachine.class);
+			EventRequestManager erm = mock(EventRequestManager.class);
+			ReferenceType refType = mock(ReferenceType.class);
+			when(service.getRawVM()).thenReturn(vm);
+			when(vm.eventRequestManager()).thenReturn(erm);
+			when(service.findOrForceLoadClass(eq("com.example.Foo"), any())).thenReturn(refType);
+			when(refType.locationsOfLine(42)).thenThrow(new AbsentInformationException("no debug info"));
+
+			int pendingId = tracker.registerPendingBreakpoint("com.example.Foo", 42, 2, "ALL");
+
+			int promoted = tracker.tryPromotePending(service, null);
+
+			assertThat(promoted).isZero();
+			assertThat(tracker.getPendingBreakpoint(pendingId))
+				.as("pending entry must stay in place so a later retry can succeed")
+				.isNotNull();
+			// The pending entry's failure reason MUST stay null — AbsentInformationException is the
+			// "try again later" branch; only terminal failures should set a failure reason.
+			assertThat(tracker.getPendingBreakpoint(pendingId).getFailureReason()).isNull();
+		}
+
+		/**
+		 * The {@code promoted} counter returned by {@link BreakpointTracker#tryPromotePending}
+		 * counts only entries that were ACTUALLY promoted by this caller — entries that lost their
+		 * recheck race (because another caller already promoted them, removed them, or marked them
+		 * failed) must not contribute to the count. Otherwise the caller's "promoted N entries"
+		 * log line would attribute work that was performed by a different thread.
+		 *
+		 * <p>This test arranges three pending line BPs against three classes; the JDI-invoke
+		 * answer-stub performs concurrent state mutations against entry A (remove) and entry B
+		 * (already-promoted) before returning. Only entry C survives the race and is promoted by
+		 * the caller, so the returned counter must be 1.
+		 */
+		@Test
+		void shouldCountOnlyActuallyPromotedEntriesWhenSomeEntriesLoseRecheckRace() throws Exception {
+			JDIConnectionService service = mock(JDIConnectionService.class);
+			VirtualMachine vm = mock(VirtualMachine.class);
+			EventRequestManager erm = mock(EventRequestManager.class);
+			ReferenceType refTypeA = mock(ReferenceType.class, "refTypeA");
+			ReferenceType refTypeB = mock(ReferenceType.class, "refTypeB");
+			ReferenceType refTypeC = mock(ReferenceType.class, "refTypeC");
+			Location locC = mock(Location.class);
+			BreakpointRequest bpC = mock(BreakpointRequest.class, "bpC");
+			BreakpointRequest listenerBpB = mock(BreakpointRequest.class, "listenerBpB");
+			when(service.getRawVM()).thenReturn(vm);
+			when(vm.eventRequestManager()).thenReturn(erm);
+
+			int idA = tracker.registerPendingBreakpoint("com.example.A", 10, 2, "ALL");
+			int idB = tracker.registerPendingBreakpoint("com.example.B", 20, 2, "ALL");
+			int idC = tracker.registerPendingBreakpoint("com.example.C", 30, 2, "ALL");
+
+			// A: removed under the worker's feet during its JDI invoke.
+			when(service.findOrForceLoadClass(eq("com.example.A"), any()))
+				.thenAnswer(inv -> {
+					tracker.removePendingBreakpoint(idA);
+					return refTypeA;
+				});
+			// B: promoted by another caller while the worker is parked.
+			when(service.findOrForceLoadClass(eq("com.example.B"), any()))
+				.thenAnswer(inv -> {
+					tracker.promotePendingToActive(idB, listenerBpB);
+					return refTypeB;
+				});
+			// C: a clean promotion path — survives the race.
+			when(service.findOrForceLoadClass(eq("com.example.C"), any())).thenReturn(refTypeC);
+			when(refTypeC.locationsOfLine(30)).thenReturn(List.of(locC));
+			when(erm.createBreakpointRequest(locC)).thenReturn(bpC);
+
+			int promoted = tracker.tryPromotePending(service, null);
+
+			assertThat(promoted)
+				.as("only entry C was actually promoted by this caller — A and B lost their recheck race")
+				.isEqualTo(1);
+			assertThat(tracker.getBreakpoint(idB))
+				.as("entry B remains bound to the listener-side BP")
+				.isSameAs(listenerBpB);
+			assertThat(tracker.getBreakpoint(idC)).isSameAs(bpC);
+		}
+	}
+
+	/**
+	 * Guards the already-promoted contract on the {@link BreakpointTracker} promotion methods.
+	 * {@code promotePendingToActive} and {@code promotePendingExceptionToActive} are called from
+	 * two paths that race against each other for the same pending entry — the JDI listener thread
+	 * (on a {@code ClassPrepareEvent}) and the safety-net {@link BreakpointTracker#tryPromotePending}.
+	 * The first promotion must win; the second must observe the existing active entry, return
+	 * {@code false}, and leave callers to tear down the orphan JDI request they just created.
+	 */
+	@Nested
+	@DisplayName("Double-promotion guard")
+	class DoublePromotionGuard {
+
+		@Test
+		void promotePendingToActive_rejectsSecondPromotionForSameId() {
+			int id = tracker.registerPendingBreakpoint("com.example.Foo", 42, 2, "ALL");
+			BreakpointRequest bp1 = mock(BreakpointRequest.class, "bp1");
+			BreakpointRequest bp2 = mock(BreakpointRequest.class, "bp2");
+
+			boolean firstResult = tracker.promotePendingToActive(id, bp1);
+			boolean secondResult = tracker.promotePendingToActive(id, bp2);
+
+			assertThat(firstResult)
+				.as("first promotion succeeds")
+				.isTrue();
+			assertThat(secondResult)
+				.as("second promotion for the same synthetic id is rejected — caller must delete the orphan request")
+				.isFalse();
+			assertThat(tracker.getBreakpoint(id))
+				.as("first-arrived request wins — bp2 must NOT overwrite bp1 in the active map")
+				.isSameAs(bp1);
+			assertThat(tracker.findIdByRequest(bp1))
+				.as("reverse index for the winning request is preserved")
+				.isEqualTo(id);
+			assertThat(tracker.findIdByRequest(bp2))
+				.as("losing request must NOT appear in the reverse index — would be a ghost entry")
+				.isNull();
+		}
+
+		@Test
+		void promotePendingExceptionToActive_rejectsSecondPromotionForSameId() {
+			int id = tracker.registerPendingExceptionBreakpoint(
+				ExceptionBreakpointSpec.suspending("com.example.MyException", true, true));
+			ExceptionRequest exReq1 = mock(ExceptionRequest.class, "exReq1");
+			ExceptionRequest exReq2 = mock(ExceptionRequest.class, "exReq2");
+
+			boolean firstResult = tracker.promotePendingExceptionToActive(id, exReq1);
+			boolean secondResult = tracker.promotePendingExceptionToActive(id, exReq2);
+
+			assertThat(firstResult)
+				.as("first promotion succeeds")
+				.isTrue();
+			assertThat(secondResult)
+				.as("second promotion for the same synthetic id is rejected — caller must delete the orphan request")
+				.isFalse();
+			assertThat(tracker.getAllExceptionBreakpoints().get(id).getRequest())
+				.as("first-arrived request wins — exReq2 must NOT overwrite exReq1 in the active map")
+				.isSameAs(exReq1);
+			assertThat(tracker.findExceptionIdByRequest(exReq1))
+				.as("reverse index for the winning request is preserved")
+				.isEqualTo(id);
+			assertThat(tracker.findExceptionIdByRequest(exReq2))
+				.as("losing request must NOT appear in the reverse index — would be a ghost entry")
+				.isNull();
 		}
 	}
 

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerExceptionAndMetadataTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerExceptionAndMetadataTest.java
@@ -907,6 +907,37 @@ class BreakpointTrackerExceptionAndMetadataTest {
 				.isNull();
 		}
 
+		/**
+		 * The pending entry can disappear between the listener's class-prepare snapshot and the call
+		 * to {@code promotePendingToActive} — most commonly because the user cleared the breakpoint
+		 * via {@code clearBreakpoint}. Without this guard, late class-prepare promotion would resurrect
+		 * a breakpoint the user has already removed: no active entry exists, the {@code containsKey}
+		 * check passes, and the orphan {@link BreakpointRequest} gets installed under the recycled id.
+		 */
+		@Test
+		void promotePendingToActive_returnsFalseWhenPendingEntryWasClearedConcurrently() {
+			int id = tracker.registerPendingBreakpoint("com.example.Foo", 42, 2, "ALL");
+			// Simulate the user clearing the pending entry between the listener's snapshot of
+			// pendingList and the call to promotePendingToActive.
+			assertThat(tracker.removePendingBreakpoint(id))
+				.as("precondition: the pending entry exists before the simulated clear")
+				.isTrue();
+
+			BreakpointRequest bp = mock(BreakpointRequest.class);
+			boolean result = tracker.promotePendingToActive(id, bp);
+
+			assertThat(result)
+				.as("late class-prepare promotion must observe the cleared pending entry and refuse "
+					+ "to install — caller will delete the orphan request")
+				.isFalse();
+			assertThat(tracker.getBreakpoint(id))
+				.as("no active breakpoint may be created from a cleared pending entry")
+				.isNull();
+			assertThat(tracker.findIdByRequest(bp))
+				.as("the orphan request must NOT appear in the reverse index — would be a ghost entry")
+				.isNull();
+		}
+
 		@Test
 		void promotePendingExceptionToActive_rejectsSecondPromotionForSameId() {
 			int id = tracker.registerPendingExceptionBreakpoint(

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerFieldBreakpointTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerFieldBreakpointTest.java
@@ -352,4 +352,85 @@ class BreakpointTrackerFieldBreakpointTest {
 		verify(erm).deleteEventRequest(accessReq);
 		assertThat(tracker.getAllFieldBreakpoints()).doesNotContainKey(id);
 	}
+
+	/**
+	 * Recheck-race coverage for the field BP arm: while the worker is parked in
+	 * {@code findOrForceLoadClass}, the listener path promotes the same pending entry via
+	 * {@link BreakpointTracker#promotePendingFieldsForClass}. When the worker re-acquires the
+	 * tracker monitor, its recheck observes that the pending entry is gone and short-circuits
+	 * without invoking {@code erm.createAccessWatchpointRequest} a second time — otherwise a
+	 * duplicate watchpoint would be armed on the target VM with the listener-side info already
+	 * bound under the synthetic id.
+	 */
+	@Test
+	@DisplayName("tryPromotePending returns 0 for field BP when another caller has promoted it during class load")
+	void shouldReturnZeroForFieldBpWhenAnotherCallerHasPromotedItWhileWorkerIsResolvingClass() throws Exception {
+		JDIConnectionService service = mock(JDIConnectionService.class);
+		VirtualMachine vm = mock(VirtualMachine.class);
+		EventRequestManager erm = mock(EventRequestManager.class);
+		ReferenceType refType = mock(ReferenceType.class);
+		AccessWatchpointRequest listenerAccessReq = mock(AccessWatchpointRequest.class, "listenerAccessReq");
+		when(service.getRawVM()).thenReturn(vm);
+		when(vm.eventRequestManager()).thenReturn(erm);
+
+		BreakpointTracker.FieldBreakpointSpec spec = BreakpointTracker.FieldBreakpointSpec.suspending(
+			"com.x.Foo", "bar", BreakpointTracker.FieldWatchMode.ACCESS, null, null, null);
+		int pendingId = tracker.registerPendingFieldBreakpoint(spec);
+
+		// While the worker is parked, simulate the listener-side promotion: remove the pending
+		// entry and insert the listener's access request under the same synthetic id.
+		when(service.findOrForceLoadClass(eq("com.x.Foo"), any()))
+			.thenAnswer(inv -> {
+				tracker.promotePendingFieldToActive(pendingId, listenerAccessReq, null);
+				return refType;
+			});
+
+		int promoted = tracker.tryPromotePending(service, null);
+
+		assertThat(promoted)
+			.as("worker must observe that the pending entry is gone and skip its own creation path")
+			.isZero();
+		assertThat(tracker.getAllFieldBreakpoints().get(pendingId).getAccessRequest())
+			.as("the listener-side request must remain bound to the synthetic id")
+			.isSameAs(listenerAccessReq);
+		verify(erm, org.mockito.Mockito.never()).createAccessWatchpointRequest(org.mockito.ArgumentMatchers.any());
+	}
+
+	/**
+	 * Recheck-race coverage for the field BP arm when the pending entry has been marked failed
+	 * (e.g. by a concurrent classifier that detected an ambiguous field) while the worker is
+	 * parked in {@code findOrForceLoadClass}. The worker's recheck observes the non-null
+	 * failure reason and skips creation — both to avoid duplicating the classifier's work and to
+	 * preserve the failure reason for {@code jdwp_overview} rendering.
+	 */
+	@Test
+	@DisplayName("tryPromotePending returns 0 for field BP when entry is marked failed during class load")
+	void shouldReturnZeroAndSkipEntryWhenPendingFieldBpIsMarkedFailedWhileWorkerIsResolvingClass() throws Exception {
+		JDIConnectionService service = mock(JDIConnectionService.class);
+		VirtualMachine vm = mock(VirtualMachine.class);
+		EventRequestManager erm = mock(EventRequestManager.class);
+		ReferenceType refType = mock(ReferenceType.class);
+		when(service.getRawVM()).thenReturn(vm);
+		when(vm.eventRequestManager()).thenReturn(erm);
+
+		BreakpointTracker.FieldBreakpointSpec spec = BreakpointTracker.FieldBreakpointSpec.suspending(
+			"com.x.Foo", "bar", BreakpointTracker.FieldWatchMode.ACCESS, null, null, null);
+		int pendingId = tracker.registerPendingFieldBreakpoint(spec);
+
+		when(service.findOrForceLoadClass(eq("com.x.Foo"), any()))
+			.thenAnswer(inv -> {
+				tracker.markPendingFieldFailed(pendingId, "ambiguous field — classifier marked failed");
+				return refType;
+			});
+
+		int promoted = tracker.tryPromotePending(service, null);
+
+		assertThat(promoted).isZero();
+		assertThat(tracker.getAllPendingFieldBreakpoints().get(pendingId).getFailureReason())
+			.isEqualTo("ambiguous field — classifier marked failed");
+		// Verify no JDI request creation was attempted — the worker observed the failure reason
+		// and short-circuited before touching the EventRequestManager.
+		verify(erm, org.mockito.Mockito.never()).createAccessWatchpointRequest(org.mockito.ArgumentMatchers.any());
+		verify(erm, org.mockito.Mockito.never()).createModificationWatchpointRequest(org.mockito.ArgumentMatchers.any());
+	}
 }

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerPromotionDeadlockTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerPromotionDeadlockTest.java
@@ -1,0 +1,364 @@
+package one.edee.mcp.jdwp;
+
+import com.sun.jdi.Field;
+import com.sun.jdi.Location;
+import com.sun.jdi.ReferenceType;
+import com.sun.jdi.ThreadReference;
+import com.sun.jdi.VirtualMachine;
+import com.sun.jdi.request.AccessWatchpointRequest;
+import com.sun.jdi.request.BreakpointRequest;
+import com.sun.jdi.request.EventRequest;
+import com.sun.jdi.request.EventRequestManager;
+import com.sun.jdi.request.ExceptionRequest;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Regression guard for the deferred-class-load monitor cycle: while a worker thread is parked
+ * inside {@link JDIConnectionService#findOrForceLoadClass} (a synchronous JDI invoke that cannot
+ * complete until the event listener drains the event queue), the JDI listener thread must still
+ * be able to acquire the {@link BreakpointTracker} monitor and finish
+ * {@link BreakpointTracker#promotePendingFieldsForClass}. Pre-fix the listener blocks on the
+ * monitor held by the worker and the target VM permanently wedges; post-fix the promotion path
+ * does its JDI roundtrip with no tracker monitor held, so the listener proceeds immediately.
+ *
+ * <p>Three variants cover the three monitor-held-across-invoke call sites in
+ * {@code tryPromotePending} — line BP, exception BP, and field BP — so a partial fix that only
+ * addresses one path is caught by the other two. Each variant also asserts the post-release
+ * behaviour: once the simulated JDI invoke returns, the worker must finish promotion (active
+ * entry visible under the same synthetic id) instead of silently no-oping.
+ */
+class BreakpointTrackerPromotionDeadlockTest {
+
+	/** Time the listener thread gets to either complete or settle into BLOCKED on the monitor. */
+	private static final long LISTENER_OBSERVATION_WINDOW_MS = 1_000L;
+
+	/** Bound on how long the simulated JDI invoke waits before giving up — must exceed the observation window. */
+	private static final long WORKER_RELEASE_TIMEOUT_S = 5L;
+
+	@Test
+	@DisplayName("line-BP promotion: listener can promote in parallel and worker completes after release")
+	void lineBreakpointPromotion_listenerProceedsAndWorkerPromotesAfterRelease() throws Exception {
+		BreakpointTracker tracker = new BreakpointTracker();
+		JDIConnectionService service = mock(JDIConnectionService.class);
+		VirtualMachine vm = mock(VirtualMachine.class);
+		EventRequestManager erm = mock(EventRequestManager.class);
+		ReferenceType refType = mock(ReferenceType.class);
+		Location loc = mock(Location.class);
+		BreakpointRequest bp = mock(BreakpointRequest.class);
+
+		when(service.getRawVM()).thenReturn(vm);
+		when(vm.eventRequestManager()).thenReturn(erm);
+		when(refType.name()).thenReturn("com.x.Foo");
+		lenient().when(refType.locationsOfLine(42)).thenReturn(List.of(loc));
+		lenient().when(erm.createBreakpointRequest(loc)).thenReturn(bp);
+
+		int pendingId = tracker.registerPendingBreakpoint("com.x.Foo", 42, EventRequest.SUSPEND_ALL, "ALL");
+
+		runDeadlockProbe(tracker, service, vm, erm, refType);
+
+		assertThat(tracker.getBreakpoint(pendingId))
+			.as("line BP must be promoted to active after the worker's simulated invoke returns")
+			.isSameAs(bp);
+	}
+
+	@Test
+	@DisplayName("exception-BP promotion: listener can promote in parallel and worker completes after release")
+	void exceptionBreakpointPromotion_listenerProceedsAndWorkerPromotesAfterRelease() throws Exception {
+		BreakpointTracker tracker = new BreakpointTracker();
+		JDIConnectionService service = mock(JDIConnectionService.class);
+		VirtualMachine vm = mock(VirtualMachine.class);
+		EventRequestManager erm = mock(EventRequestManager.class);
+		ReferenceType refType = mock(ReferenceType.class);
+		ExceptionRequest exReq = mock(ExceptionRequest.class);
+
+		when(service.getRawVM()).thenReturn(vm);
+		when(vm.eventRequestManager()).thenReturn(erm);
+		when(refType.name()).thenReturn("com.x.Foo");
+		lenient().when(erm.createExceptionRequest(refType, true, true)).thenReturn(exReq);
+
+		int pendingId = tracker.registerPendingExceptionBreakpoint(
+			BreakpointTracker.ExceptionBreakpointSpec.suspending("com.x.Foo", true, true));
+
+		runDeadlockProbe(tracker, service, vm, erm, refType);
+
+		assertThat(tracker.getAllExceptionBreakpoints().get(pendingId))
+			.as("exception BP must be promoted to active after the worker's simulated invoke returns")
+			.isNotNull();
+		assertThat(tracker.getAllExceptionBreakpoints().get(pendingId).getRequest()).isSameAs(exReq);
+	}
+
+	@Test
+	@DisplayName("field-BP promotion: listener can promote in parallel and worker completes after release")
+	void fieldBreakpointPromotion_listenerProceedsAndWorkerPromotesAfterRelease() throws Exception {
+		BreakpointTracker tracker = new BreakpointTracker();
+		JDIConnectionService service = mock(JDIConnectionService.class);
+		VirtualMachine vm = mock(VirtualMachine.class);
+		EventRequestManager erm = mock(EventRequestManager.class);
+		ReferenceType refType = mock(ReferenceType.class);
+		Field field = mock(Field.class);
+		AccessWatchpointRequest accessReq = mock(AccessWatchpointRequest.class);
+
+		when(service.getRawVM()).thenReturn(vm);
+		when(vm.eventRequestManager()).thenReturn(erm);
+		when(refType.name()).thenReturn("com.x.Foo");
+		lenient().when(refType.allFields()).thenReturn(List.of(field));
+		lenient().when(field.name()).thenReturn("bar");
+		lenient().when(field.isStatic()).thenReturn(false);
+		lenient().when(erm.createAccessWatchpointRequest(field)).thenReturn(accessReq);
+
+		int pendingId = tracker.registerPendingFieldBreakpoint(BreakpointTracker.FieldBreakpointSpec.suspending(
+			"com.x.Foo", "bar", BreakpointTracker.FieldWatchMode.ACCESS, null, null, null));
+
+		runDeadlockProbe(tracker, service, vm, erm, refType);
+
+		assertThat(tracker.getAllFieldBreakpoints().get(pendingId))
+			.as("field BP must be promoted to active after the worker's simulated invoke returns")
+			.isNotNull();
+		assertThat(tracker.getAllFieldBreakpoints().get(pendingId).getAccessRequest()).isSameAs(accessReq);
+	}
+
+	/**
+	 * Recheck-race coverage for the field BP arm: while the worker is parked inside
+	 * {@link JDIConnectionService#findOrForceLoadClass}, the JDI listener calls
+	 * {@link BreakpointTracker#promotePendingFieldsForClass} on the same {@code ReferenceType} and
+	 * wins the race. When the worker eventually re-acquires the tracker monitor, its recheck must
+	 * observe that the pending entry has been removed and return 0 promotions instead of double-
+	 * promoting the same synthetic id onto a second watchpoint request.
+	 */
+	@Test
+	@DisplayName("field-BP tryPromotePending returns 0 when listener wins the promotion race")
+	void tryPromotePending_returnsZeroWhenListenerPromotesFieldEntryWhileWorkerIsParkedInJdiInvoke() throws Exception {
+		BreakpointTracker tracker = new BreakpointTracker();
+		JDIConnectionService service = mock(JDIConnectionService.class);
+		VirtualMachine vm = mock(VirtualMachine.class);
+		EventRequestManager erm = mock(EventRequestManager.class);
+		ReferenceType refType = mock(ReferenceType.class);
+		Field field = mock(Field.class);
+		AccessWatchpointRequest workerAccessReq = mock(AccessWatchpointRequest.class, "workerAccessReq");
+		AccessWatchpointRequest listenerAccessReq = mock(AccessWatchpointRequest.class, "listenerAccessReq");
+
+		when(service.getRawVM()).thenReturn(vm);
+		when(vm.eventRequestManager()).thenReturn(erm);
+		when(refType.name()).thenReturn("com.x.Foo");
+		when(refType.allFields()).thenReturn(List.of(field));
+		when(field.name()).thenReturn("bar");
+		when(field.isStatic()).thenReturn(false);
+		// First call (from the listener while the worker is parked) returns the listener's request;
+		// any subsequent call (e.g. if the recheck failed to short-circuit) would observe the worker
+		// request — making a missed recheck visible as a second watchpoint armed on the target VM.
+		when(erm.createAccessWatchpointRequest(field))
+			.thenReturn(listenerAccessReq)
+			.thenReturn(workerAccessReq);
+
+		int pendingId = tracker.registerPendingFieldBreakpoint(BreakpointTracker.FieldBreakpointSpec.suspending(
+			"com.x.Foo", "bar", BreakpointTracker.FieldWatchMode.ACCESS, null, null, null));
+
+		CountDownLatch workerInsideInvoke = new CountDownLatch(1);
+		CountDownLatch releaseWorker = new CountDownLatch(1);
+		when(service.findOrForceLoadClass(eq("com.x.Foo"), any()))
+			.thenAnswer(inv -> {
+				workerInsideInvoke.countDown();
+				if (!releaseWorker.await(WORKER_RELEASE_TIMEOUT_S, TimeUnit.SECONDS)) {
+					throw new IllegalStateException("worker latch timed out");
+				}
+				return refType;
+			});
+
+		AtomicBoolean workerSawPromotion = new AtomicBoolean(false);
+		Thread worker = new Thread(() -> {
+			int promoted = tracker.tryPromotePending(service, null);
+			workerSawPromotion.set(promoted > 0);
+		}, "field-recheck-race-worker");
+		worker.setDaemon(true);
+		worker.start();
+
+		assertThat(workerInsideInvoke.await(2, TimeUnit.SECONDS))
+			.as("worker must reach the simulated JDI invoke within 2s")
+			.isTrue();
+
+		// Listener promotes the entry while the worker is parked. This is the actual race we're
+		// modelling — handleClassPrepareEvent calls promotePendingFieldsForClass synchronously.
+		int listenerPromoted = tracker.promotePendingFieldsForClass(refType, vm, erm, service);
+		assertThat(listenerPromoted)
+			.as("listener path must promote the entry while the worker is still parked")
+			.isEqualTo(1);
+
+		releaseWorker.countDown();
+		worker.join(WORKER_RELEASE_TIMEOUT_S * 1_000);
+
+		assertThat(workerSawPromotion.get())
+			.as("worker's recheck must observe the listener-side promotion and return 0 promotions")
+			.isFalse();
+		assertThat(tracker.getAllFieldBreakpoints().get(pendingId).getAccessRequest())
+			.as("the listener-side request must remain bound under the synthetic id — not the worker's")
+			.isSameAs(listenerAccessReq);
+	}
+
+	/**
+	 * Guards the outer-monitor decoupling between {@link JDIConnectionService} and
+	 * {@link BreakpointTracker#tryPromotePending}: {@code JDIConnectionService.getVM()} must NOT
+	 * hold the service monitor across the call to {@code tryPromotePending}, because that path can
+	 * park inside a JDI {@code invokeMethod} (force-loading a deferred class) for the duration of
+	 * the target-VM round-trip. Holding the monitor across that window would block every other
+	 * {@code getVM()} caller — and thus every other MCP tool call — until the invoke returns.
+	 *
+	 * <p>The connect / auto-reconnect work still runs under the monitor; only the opportunistic
+	 * promotion call is moved outside. A second {@code getVM()} caller must therefore make progress
+	 * while the first is parked.
+	 *
+	 * <p>Because the contended monitor is the {@link JDIConnectionService} instance itself, this
+	 * test uses a real (un-mocked) {@code JDIConnectionService} with a {@link BreakpointTracker}
+	 * subclass that signals via a latch — letting the test race a second {@code getVM()} call
+	 * against the parked worker.
+	 */
+	@Test
+	@DisplayName("getVM() second caller proceeds while another thread is mid-promotion")
+	void getVm_secondCallerProceedsWhileFirstIsParkedInDeferredClassLoadPhase2() throws Exception {
+		CountDownLatch workerInsideInvoke = new CountDownLatch(1);
+		CountDownLatch releaseWorker = new CountDownLatch(1);
+
+		BreakpointTracker blockingTracker = new BreakpointTracker() {
+			@Override
+			public int tryPromotePending(@Nullable JDIConnectionService jdiService,
+			                             @Nullable ThreadReference preferredThread) {
+				workerInsideInvoke.countDown();
+				try {
+					if (!releaseWorker.await(WORKER_RELEASE_TIMEOUT_S, TimeUnit.SECONDS)) {
+						throw new IllegalStateException("worker latch timed out");
+					}
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					return 0;
+				}
+				return 0;
+			}
+		};
+
+		VirtualMachine vm = mock(VirtualMachine.class);
+		JDIConnectionService service = JDIConnectionServiceTestSupport.newServiceWithCollaborators(
+			mock(JdiEventListener.class), blockingTracker, new EventHistory(),
+			new one.edee.mcp.jdwp.watchers.WatcherManager(), new EvaluationGuard());
+		JDIConnectionServiceTestSupport.setVm(service, vm);
+		JDIConnectionServiceTestSupport.setLastSuccessfulAttach(service, "localhost", 5005);
+		when(vm.name()).thenReturn("target-vm");
+
+		Thread worker = new Thread(() -> {
+			try {
+				service.getVM();
+			} catch (Exception ignored) {
+				// We only care about the monitor-holding behaviour, not the result.
+			}
+		}, "outer-monitor-worker");
+		worker.setDaemon(true);
+		worker.start();
+
+		assertThat(workerInsideInvoke.await(2, TimeUnit.SECONDS))
+			.as("worker must reach tryPromotePending within 2s")
+			.isTrue();
+
+		Thread secondCaller = new Thread(() -> {
+			try {
+				service.getVM();
+			} catch (Exception ignored) {
+				// As above — the result is uninteresting; we are timing the monitor wait.
+			}
+		}, "outer-monitor-second-caller");
+		secondCaller.setDaemon(true);
+		secondCaller.start();
+
+		// Both callers reach the test's tryPromotePending override and park on releaseWorker —
+		// so both threads stay alive. The distinguishing signal is Thread.State: BLOCKED means the
+		// second caller is still waiting on the JDIConnectionService monitor (the broken pre-fix
+		// state), while TIMED_WAITING means it has progressed past the synchronized block and is
+		// now parked on the latch inside tryPromotePending (the fixed behaviour).
+		secondCaller.join(LISTENER_OBSERVATION_WINDOW_MS);
+		Thread.State secondState = secondCaller.getState();
+		boolean secondCallerBlockedOnMonitor = secondState == Thread.State.BLOCKED;
+
+		// Always release so the test does not leak threads even when the assertion fails.
+		releaseWorker.countDown();
+		worker.join(WORKER_RELEASE_TIMEOUT_S * 1_000);
+		secondCaller.join(WORKER_RELEASE_TIMEOUT_S * 1_000);
+
+		assertThat(secondCallerBlockedOnMonitor)
+			.as("a second getVM() caller must NOT block on the JDIConnectionService monitor while "
+				+ "an unrelated worker is parked inside tryPromotePending — the monitor must be "
+				+ "released across the promotion call. Observed state: %s.", secondState)
+			.isFalse();
+	}
+
+	/**
+	 * Drives the worker into a simulated parked-JDI-invoke and observes whether the listener-side
+	 * monitor acquire can make progress. Pre-fix the listener blocks on the tracker monitor held
+	 * by the worker and stays alive past {@link #LISTENER_OBSERVATION_WINDOW_MS}; post-fix the
+	 * listener completes immediately and the assertion below passes. Also asserts both threads
+	 * terminate cleanly after the release latch.
+	 */
+	private static void runDeadlockProbe(BreakpointTracker tracker, JDIConnectionService service,
+	                                     VirtualMachine vm, EventRequestManager erm,
+	                                     ReferenceType refType) throws Exception {
+		CountDownLatch workerInsideInvoke = new CountDownLatch(1);
+		CountDownLatch releaseWorker = new CountDownLatch(1);
+
+		// Simulate the parked JDI invoke: signal that the worker is "inside JDI", then block
+		// until the listener side has had its chance to run. The fix moves this call outside the
+		// BreakpointTracker monitor, so the listener can acquire the monitor while we wait here.
+		when(service.findOrForceLoadClass(eq("com.x.Foo"), any()))
+			.thenAnswer(inv -> {
+				workerInsideInvoke.countDown();
+				if (!releaseWorker.await(WORKER_RELEASE_TIMEOUT_S, TimeUnit.SECONDS)) {
+					throw new IllegalStateException("worker latch timed out — test orchestration bug");
+				}
+				return refType;
+			});
+
+		Thread worker = new Thread(() -> tracker.tryPromotePending(service, null), "deadlock-probe-worker");
+		worker.setDaemon(true);
+		worker.start();
+
+		assertThat(workerInsideInvoke.await(2, TimeUnit.SECONDS))
+			.as("worker must reach the simulated JDI invoke within 2s")
+			.isTrue();
+
+		Thread listener = new Thread(
+			() -> tracker.promotePendingFieldsForClass(refType, vm, erm, service),
+			"deadlock-probe-listener");
+		listener.setDaemon(true);
+		listener.start();
+
+		listener.join(LISTENER_OBSERVATION_WINDOW_MS);
+		boolean listenerBlocked = listener.isAlive();
+		Thread.State listenerState = listener.getState();
+
+		// Always release the worker so the test does not leak threads regardless of the assertion outcome.
+		releaseWorker.countDown();
+		worker.join(WORKER_RELEASE_TIMEOUT_S * 1_000);
+		listener.join(WORKER_RELEASE_TIMEOUT_S * 1_000);
+
+		assertThat(listenerBlocked)
+			.as("promotePendingFieldsForClass must not block on the BreakpointTracker monitor "
+				+ "while a worker is parked inside findOrForceLoadClass — listener state observed: %s",
+				listenerState)
+			.isFalse();
+		assertThat(worker.isAlive())
+			.as("worker thread must terminate after the JDI invoke simulation releases")
+			.isFalse();
+		assertThat(listener.isAlive())
+			.as("listener thread must terminate cleanly")
+			.isFalse();
+	}
+}

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerPromotionDeadlockTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerPromotionDeadlockTest.java
@@ -341,16 +341,20 @@ class BreakpointTrackerPromotionDeadlockTest {
 		listener.start();
 
 		listener.join(LISTENER_OBSERVATION_WINDOW_MS);
-		boolean listenerBlocked = listener.isAlive();
+		// Distinguish "blocked on the tracker monitor" (the pre-fix deadlock — Thread.State.BLOCKED)
+		// from "still running but slow under a loaded CI host" (Thread.State.RUNNABLE / WAITING /
+		// TIMED_WAITING — not a deadlock, must not fail the test). Same pattern as
+		// getVm_secondCallerProceedsWhileFirstIsParkedInDeferredClassLoadPhase2 below.
 		Thread.State listenerState = listener.getState();
+		boolean listenerBlockedOnMonitor = listenerState == Thread.State.BLOCKED;
 
 		// Always release the worker so the test does not leak threads regardless of the assertion outcome.
 		releaseWorker.countDown();
 		worker.join(WORKER_RELEASE_TIMEOUT_S * 1_000);
 		listener.join(WORKER_RELEASE_TIMEOUT_S * 1_000);
 
-		assertThat(listenerBlocked)
-			.as("promotePendingFieldsForClass must not block on the BreakpointTracker monitor "
+		assertThat(listenerBlockedOnMonitor)
+			.as("promotePendingFieldsForClass must not be BLOCKED on the BreakpointTracker monitor "
 				+ "while a worker is parked inside findOrForceLoadClass — listener state observed: %s",
 				listenerState)
 			.isFalse();


### PR DESCRIPTION
## Summary
- Fixes the deferred-class-load monitor cycle described in #1 — `tryPromotePending` no longer holds the `BreakpointTracker` monitor across `findOrForceLoadClass`, so the JDI event listener can drain the events that `Class.forName(...)` produces and the target VM is no longer wedged.
- Splits `JDIConnectionService.findOrForceLoadClass` into three phases (lookup under monitor → `invokeMethod` outside monitor → post-invoke lookup on the captured `vmRef`), and restructures `getVM()` to release its monitor before calling `tryPromotePending`. Together these close the reentrant-hold variant of the same cycle on the connection-service monitor.
- Bonus during code review: closes two HIGH double-promotion races where `promotePendingToActive` / `promotePendingExceptionToActive` could be called concurrently by the worker and the listener, leaving a ghost JDI request armed on the target VM with a stale reverse-index entry. Both methods are now `synchronized` and return `boolean`; all call sites delete the surplus request on `false`.

## Closes
Closes #1

## What changed
- `BreakpointTracker.tryPromotePending` — snapshot-then-per-entry-recheck refactor; method no longer `synchronized`.
- `BreakpointTracker.promotePendingToActive` / `promotePendingExceptionToActive` — `synchronized`, returns `boolean`.
- `JDIConnectionService.findOrForceLoadClass` — three-phase split, `invokeMethod` runs without the monitor.
- `JDIConnectionService.getVM()` — releases the connection-service monitor before calling `tryPromotePending`.
- `JdiEventListener.handleClassPrepareEvent` and `JDWPTools` race-guard paths — delete the orphan JDI request when the promote method returns `false`.
- New test class `BreakpointTrackerPromotionDeadlockTest` covers all three deadlock variants deterministically (line / exception / field BP) plus the connection-service-monitor variant.
- Additional sister tests in `BreakpointTrackerExceptionAndMetadataTest` and `BreakpointTrackerFieldBreakpointTest` pin every recheck branch and the new `boolean` contract on the promote-active methods.
- Tightened Javadoc on the changed APIs; stripped two unrelated stale ephemeral references (`P0-2/P0-3`, `F-RA2`) from in-tree Javadoc spotted during the audit.
- `evaluation/{ClasspathDiscoverer,InMemoryJavaCompiler,JdkDiscoveryService}.java` — wrapped angle-bracketed tokens (`<jdkPath>`, `<name>` etc.) in `{@code ...}` so `mvn javadoc:javadoc` no longer fails on "unknown tag".

## Test plan
- [x] `mvn -pl jdwp-mcp-server test` — **875 tests, 0 failures, 0 errors, 2 pre-existing skips**.
- [x] `mvn -pl jdwp-mcp-server compile` — clean, no NullAway diagnostics introduced.
- [x] `mvn -pl jdwp-mcp-server javadoc:javadoc` — BUILD SUCCESS, 0 errors (warnings are all pre-existing missing-`@param` on package-private methods).
- [x] Pre-fix verification — confirmed the three `BreakpointTrackerPromotionDeadlockTest` variants observe `listener state: BLOCKED` against the pre-refactor `BreakpointTracker`.
- [x] Manual sweep — no `// Known limitation`, `// FIXME`, or `BUG-NNN` markers introduced; no ephemeral references in Javadoc / comments / test names.