### PR TITLE
fix: make breakpoint registration passive by default (forceLoad opt-in)

### DIFF
--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/BreakpointTracker.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/BreakpointTracker.java
@@ -45,15 +45,13 @@ import java.util.concurrent.atomic.AtomicInteger;
  *       removal that spans both maps, {@code clearAll}, and the pending-side registrations whose
  *       atomicity matters for {@link #tryPromotePending}'s recheck-and-mutate critical section.</li>
  *   <li>{@link #tryPromotePending} is the documented exception to the "single critical section"
- *       pattern: it cannot hold the tracker monitor across
- *       {@link JDIConnectionService#findOrForceLoadClass}, because that call parks the worker
- *       inside a target-VM {@code invokeMethod} until the JDI event listener drains the resulting
- *       events — and the listener itself takes this monitor in
- *       {@link #promotePendingFieldsForClass}. So {@code tryPromotePending} snapshots the pending
- *       maps under the monitor, releases it across each per-entry force-load round-trip, then
- *       re-acquires it for a recheck-and-mutate critical section. The {@code promote*} methods
- *       are the authoritative already-promoted guard; losers in that race tear down their orphan
- *       JDI request.</li>
+ *       pattern: it snapshots the pending maps under the monitor, releases it across each
+ *       per-entry passive lookup (via {@link JDIConnectionService#findLoadedClass}), then
+ *       re-acquires it for a recheck-and-mutate critical section. The lookup is intentionally
+ *       passive — driving force-loads from this safety net was the root cause of the
+ *       deferred-class-load deadlock (GH issue #2) and the breakpoint-induced behaviour change
+ *       (GH issue #3). The {@code promote*} methods are the authoritative already-promoted guard;
+ *       losers in the race tear down their orphan JDI request.</li>
  *   <li>The {@code lastBreakpoint*} fields are {@code volatile} for cross-thread visibility from
  *       the JDI listener thread to MCP worker threads.</li>
  * </ul>
@@ -873,38 +871,38 @@ public class BreakpointTracker {
 
     /**
      * Re-attempts to promote every pending entry — line BPs, exception BPs, and field watchpoints —
-     * by re-querying `vm.classesByName(...)`. This is the safety net for cases where
-     * {@link ClassPrepareRequest} does not fire — most notably bootstrap classes loaded by the JVM
-     * before any debugger event is delivered.
+     * by re-querying {@link JDIConnectionService#findLoadedClass} (passive,
+     * side-effect free). This is the safety net for cases where {@link ClassPrepareRequest} does
+     * not fire — most notably bootstrap classes loaded by the JVM before any debugger event is
+     * delivered.
      * <p>
      * Called from {@link JDIConnectionService#getVM()} (every MCP tool call) and
      * from {@link JdiEventListener} (after every JDI event), so any user interaction
      * gives pending items another chance to bind. Best-effort; transient failures are logged at
      * debug and the item stays pending for the next retry.
      * <p>
+     * The lookup is intentionally <i>passive</i>: it never invokes {@code Class.forName} in the
+     * target VM. The safety net's job is to catch classes that loaded while we weren't looking,
+     * not to drive new loads. Driving loads here was the root cause of the deferred-class-load
+     * deadlock pattern (GH issue #2) and changed target-application behaviour (GH issue #3); both
+     * are eliminated by making this strictly observational.
+     * <p>
      * Field BPs additionally roll back any partially-created JDI requests if promotion fails
      * mid-flight (a {@code BOTH}-mode entry creates two requests, either of which can throw) and
      * mark the pending entry failed so subsequent cycles do not retry the same orphan-prone path.
      * <p>
-     * <b>Concurrency:</b> the method is intentionally not {@code synchronized}. Two monitors are
-     * relevant — the tracker monitor (this object) and the {@link JDIConnectionService} monitor.
-     * The pending maps are snapshotted under the tracker monitor here, then each pending entry is
-     * resolved by calling {@link JDIConnectionService#findOrForceLoadClass} <i>without</i> the
-     * tracker monitor held: that call can park inside a target-VM {@code invokeMethod} that only
-     * returns once our event listener drains the resulting events, and the listener takes this
-     * same tracker monitor in {@link #promotePendingFieldsForClass}. The per-entry mutation step
-     * re-acquires the tracker monitor with a recheck that the entry is still pending and that no
-     * other path (listener or a sibling {@link #tryPromotePending} caller) has already promoted
-     * it — the recheck is defense in depth on top of the already-promoted guard inside the
-     * promote* methods themselves. Orphan JDI requests that lose the race are deleted from the
+     * <b>Concurrency:</b> the method is intentionally not {@code synchronized}. The pending maps
+     * are snapshotted under the tracker monitor here, then each entry's per-class lookup runs
+     * without the monitor (cheap and side-effect free), and the per-entry mutation step re-acquires
+     * the tracker monitor with a recheck that the entry is still pending and that no other path
+     * (listener or a sibling {@link #tryPromotePending} caller) has already promoted it. The
+     * recheck is defense in depth on top of the already-promoted guard inside the promote* methods
+     * themselves. Orphan JDI requests that lose the race are deleted from the
      * {@link EventRequestManager}.
      *
      * @return number of items promoted in this call
      */
-    public int tryPromotePending(
-        @Nullable JDIConnectionService jdiService,
-        @Nullable ThreadReference preferredThread
-    ) {
+    public int tryPromotePending(@Nullable JDIConnectionService jdiService) {
         if (jdiService == null) {
             return 0;
         }
@@ -940,7 +938,11 @@ public class BreakpointTracker {
             }
 
             try {
-                final ReferenceType refType = jdiService.findOrForceLoadClass(pending.getClassName(), preferredThread);
+                // Passive lookup only — the listener path is the authoritative promoter for the
+                // natural-load case, and force-loading from the safety net would re-introduce the
+                // very side effects this codebase moved away from in GH issue #3 (early <clinit>,
+                // masked lazy-load diagnostics, the deferred-class-load deadlock pattern).
+                final ReferenceType refType = jdiService.findLoadedClass(pending.getClassName());
                 if (refType == null) {
                     continue;
                 }
@@ -990,7 +992,7 @@ public class BreakpointTracker {
             }
 
             try {
-                final ReferenceType refType = jdiService.findOrForceLoadClass(pending.getExceptionClass(), preferredThread);
+                final ReferenceType refType = jdiService.findLoadedClass(pending.getExceptionClass());
                 if (refType == null) {
                     continue;
                 }
@@ -1031,8 +1033,7 @@ public class BreakpointTracker {
                 continue;
             }
             try {
-                final ReferenceType refType = jdiService.findOrForceLoadClass(
-                    pending.getSpec().className(), preferredThread);
+                final ReferenceType refType = jdiService.findLoadedClass(pending.getSpec().className());
                 if (refType == null) {
                     continue;
                 }

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/BreakpointTracker.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/BreakpointTracker.java
@@ -949,7 +949,8 @@ public class BreakpointTracker {
 
                 synchronized (this) {
                     // Recheck: the listener path (JdiEventListener.handleClassPrepareEvent) may
-                    // have promoted or removed this entry while we were parked in the JDI invoke.
+                    // have promoted or removed this entry between the unsynchronized passive
+                    // lookup above and our re-acquire of the tracker monitor here.
                     if (pendingBreakpointsById.get(id) != pending
                         || pending.getFailureReason() != null
                         || breakpointsById.containsKey(id)) {

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JDIConnectionService.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JDIConnectionService.java
@@ -484,7 +484,7 @@ public class JDIConnectionService {
         // is never delivered. Best-effort; failures are swallowed. Runs outside the service monitor
         // (see class-level Javadoc for the rationale).
         try {
-            breakpointTracker.tryPromotePending(this, null);
+            breakpointTracker.tryPromotePending(this);
         } catch (Exception e) {
             log.debug("[JDI] Pending promotion failed: {}", e.getMessage());
         }
@@ -493,10 +493,10 @@ public class JDIConnectionService {
 
     /**
      * Returns the raw VM reference without triggering opportunistic promotion. Used by
-     * {@link BreakpointTracker#tryPromotePending(JDIConnectionService, ThreadReference)} to avoid
-     * recursion. Reads the {@code vm} field directly without taking the service monitor — the
-     * field is written under the monitor and read here as a plain reference; a stale read returns
-     * a recently-disposed {@link VirtualMachine} whose JDI calls throw {@link com.sun.jdi.VMDisconnectedException},
+     * {@link BreakpointTracker#tryPromotePending(JDIConnectionService)} to avoid recursion. Reads
+     * the {@code vm} field directly without taking the service monitor — the field is written under
+     * the monitor and read here as a plain reference; a stale read returns a recently-disposed
+     * {@link VirtualMachine} whose JDI calls throw {@link com.sun.jdi.VMDisconnectedException},
      * which the caller already handles.
      */
     @Nullable
@@ -1019,11 +1019,59 @@ public class JDIConnectionService {
     }
 
     /**
+     * Passive class lookup — checks whether {@code className} is already loaded in the target VM
+     * via two side-effect-free probes ({@link VirtualMachine#classesByName} and a full
+     * {@code allClasses()} scan) and returns the matching {@link ReferenceType} or {@code null}
+     * if the class is not yet loaded.
+     *
+     * <p>Unlike {@link #findOrForceLoadClass}, this method <i>never</i> invokes
+     * {@code Class.forName} in the target VM, so it cannot trigger {@code <clinit>}, cannot
+     * cascade-load dependencies, and cannot park the calling thread inside a target-VM
+     * {@code invokeMethod}. This is the default lookup used by every set-breakpoint code path —
+     * a debugger should observe class loads, not cause them. Callers that genuinely need to make
+     * a class appear (typically the bootstrap-class case for exception BPs, or expression /
+     * watcher evaluation that needs a specific helper class) must opt in via
+     * {@link #findOrForceLoadClass}.
+     */
+    @Nullable
+    public ReferenceType findLoadedClass(String className) {
+        final VirtualMachine vmRef;
+        synchronized (this) {
+            if (vm == null) {
+                return null;
+            }
+            vmRef = vm;
+        }
+        try {
+            final List<ReferenceType> existing = vmRef.classesByName(className);
+            if (!existing.isEmpty()) {
+                return existing.get(0);
+            }
+            // Fallback: full scan — sometimes catches bootstrap classes the indexed lookup misses.
+            return vmRef.allClasses().stream()
+                .filter(rt -> rt.name().equals(className))
+                .findFirst()
+                .orElse(null);
+        } catch (Exception e) {
+            log.debug("[JDI] Passive lookup for '{}' failed: {}", className, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
      * Locates a class in the target VM, force-loading it via {@code Class.forName(name)} if not yet
      * visible. Solves the bootstrap-class problem: classes like {@code java.lang.IllegalStateException}
      * are not visible to {@link VirtualMachine#classesByName} until first referenced, and their
      * {@link com.sun.jdi.event.ClassPrepareEvent} is not delivered to JDI clients. Returns
      * {@code null} if the class cannot be found or force-loaded.
+     *
+     * <p><b>This method has observable side effects on the target application</b> — running
+     * {@code <clinit>} triggers static-field init, cascade-loads dependencies, may register
+     * listeners and open connections, and can mask the very lazy-load diagnostics users attach a
+     * debugger to investigate. It is therefore <i>opt-in</i>: every set-breakpoint / set-logpoint
+     * MCP tool defaults to the passive {@link #findLoadedClass} path; callers must explicitly pass
+     * {@code forceLoad=true} (or call this method directly from a non-breakpoint code path such as
+     * expression evaluation) to accept the trade-off.
      *
      * <p>{@code preferredThread}, if non-null, must be suspended at a JDI method-invocation event
      * (breakpoint, step, exception, class prepare) — JDI cannot invoke methods on threads

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JDWPTools.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JDWPTools.java
@@ -1807,14 +1807,15 @@ public class JDWPTools {
         }
     }
 
-    @McpTool(description = "Set a breakpoint at a specific line in a class. Supports conditional breakpoints. If the class is not yet loaded, the breakpoint is deferred.")
+    @McpTool(description = "Set a breakpoint at a specific line in a class. Supports conditional breakpoints. By default the breakpoint is registered passively: if the class is not yet loaded, the BP is deferred via a ClassPrepareRequest and activates when the JVM loads the class on its own — same behaviour as IntelliJ / Eclipse / jdb. Pass forceLoad=true only when you need the breakpoint to bind immediately and accept that loading the class will run its <clinit> (early static init, eager dependency loads, masked lazy-load diagnostics).")
     public String jdwp_set_breakpoint(
         @McpToolParam(description = "Fully qualified class name (e.g. 'com.example.MyClass')") String className,
         @McpToolParam(description = "Line number") int lineNumber,
         @McpToolParam(required = false, description = "Suspend policy: 'all' (default), 'thread', 'none'") @Nullable String suspendPolicy,
         @McpToolParam(required = false, description = "Optional condition — only suspend when this evaluates to true (e.g., 'i > 100')") @Nullable String condition,
         @McpToolParam(required = false, description = "Optional ID of a trigger breakpoint — this BP stays disarmed until the trigger fires. Sticky by default: once armed it stays so unless re-disarmed via jdwp_disarm_until_trigger or oneShot=true.") @Nullable Integer triggerBreakpointId,
-        @McpToolParam(required = false, description = "If true, re-disarm this BP after each hit so the next trigger fire re-arms it (IntelliJ-style). Default: false (sticky).") @Nullable Boolean oneShot) {
+        @McpToolParam(required = false, description = "If true, re-disarm this BP after each hit so the next trigger fire re-arms it (IntelliJ-style). Default: false (sticky).") @Nullable Boolean oneShot,
+        @McpToolParam(required = false, description = "If true, force-load the class via Class.forName in the target VM when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Force-load triggers <clinit>, cascades dependent loads, and can mask lazy-init / classloader-leak diagnostics — use sparingly.") @Nullable Boolean forceLoad) {
         // Track the pending ID outside the try so the catch can clean it up if locationsOfLine
         // (or any later step) throws after the pending entry has already been registered.
         Integer pendingIdForCleanup = null;
@@ -1846,7 +1847,13 @@ public class JDWPTools {
             final String conditionInfo = condition != null && !condition.isBlank()
                 ? String.format(", condition: %s", condition) : "";
 
-            final ReferenceType eagerType = jdiService.findOrForceLoadClass(className);
+            final boolean effectiveForceLoad = forceLoad != null && forceLoad;
+            // Passive by default: a debugger should observe class loads, not cause them. Force-load
+            // is opt-in for the rare cases that genuinely need eager binding (bootstrap classes,
+            // tight integration tests). See GH issue #3.
+            final ReferenceType eagerType = effectiveForceLoad
+                ? jdiService.findOrForceLoadClass(className)
+                : jdiService.findLoadedClass(className);
             final List<ReferenceType> classes = eagerType != null ? List.of(eagerType) : List.of();
 
             final String chainInfo = triggerBreakpointId != null
@@ -1941,12 +1948,13 @@ public class JDWPTools {
         }
     }
 
-    @McpTool(description = "Set a logpoint (non-stopping breakpoint) that evaluates an expression and logs the result without pausing execution. Supports an optional condition — the expression is only logged when the condition evaluates to true.")
+    @McpTool(description = "Set a logpoint (non-stopping breakpoint) that evaluates an expression and logs the result without pausing execution. Supports an optional condition — the expression is only logged when the condition evaluates to true. By default the logpoint is registered passively: if the class is not yet loaded, it is deferred via a ClassPrepareRequest and activates on natural load. Pass forceLoad=true to force the class load (runs <clinit>, may mask lazy-init diagnostics).")
     public String jdwp_set_logpoint(
         @McpToolParam(description = "Fully qualified class name") String className,
         @McpToolParam(description = "Line number") int lineNumber,
         @McpToolParam(description = "Java expression to evaluate and log (e.g., '\"x=\" + x', 'order.getTotal()')") String expression,
-        @McpToolParam(required = false, description = "Optional condition — only log when this evaluates to true (e.g., 'i > 100')") @Nullable String condition) {
+        @McpToolParam(required = false, description = "Optional condition — only log when this evaluates to true (e.g., 'i > 100')") @Nullable String condition,
+        @McpToolParam(required = false, description = "If true, force-load the class via Class.forName in the target VM when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Force-load triggers <clinit> and can mask lazy-init / classloader-leak diagnostics — use sparingly.") @Nullable Boolean forceLoad) {
         // Track the pending ID outside the try so the catch can clean it up if locationsOfLine
         // (or any later step) throws after the pending entry has already been registered.
         Integer pendingIdForCleanup = null;
@@ -1959,7 +1967,10 @@ public class JDWPTools {
             final String conditionInfo = condition != null && !condition.isBlank()
                 ? String.format(", condition: %s", condition) : "";
 
-            final ReferenceType eagerType = jdiService.findOrForceLoadClass(className);
+            final boolean effectiveForceLoad = forceLoad != null && forceLoad;
+            final ReferenceType eagerType = effectiveForceLoad
+                ? jdiService.findOrForceLoadClass(className)
+                : jdiService.findLoadedClass(className);
             final List<ReferenceType> classes = eagerType != null ? List.of(eagerType) : List.of();
 
             if (classes.isEmpty()) {
@@ -2282,18 +2293,22 @@ public class JDWPTools {
 
     @McpTool(description = "Set a breakpoint that suspends the throwing thread when a specific exception " +
         "is thrown — caught at the throw site, before the stack unwinds. For non-stopping tracing, use " +
-        "jdwp_set_exception_logpoint instead. If the exception class is not yet loaded, the breakpoint is " +
-        "deferred and will activate automatically when the JVM loads it.")
+        "jdwp_set_exception_logpoint instead. By default the BP is registered passively: if the exception " +
+        "class is not yet loaded the BP is deferred via a ClassPrepareRequest and activates on natural load. " +
+        "Pass forceLoad=true when targeting an exception class the application hasn't referenced yet " +
+        "(typically a JDK exception type such as java.sql.SQLException) — accepts the side effects of " +
+        "running <clinit> in the target VM.")
     public String jdwp_set_exception_breakpoint(
         @McpToolParam(description = "Exception class name (e.g., 'java.lang.NullPointerException', 'java.lang.Exception' for all)") String exceptionClass,
         @McpToolParam(required = false, description = "Break on caught exceptions (default: true)") @Nullable Boolean caught,
         @McpToolParam(required = false, description = "Break on uncaught exceptions (default: true)") @Nullable Boolean uncaught,
         @McpToolParam(required = false, description = "Optional ID of a trigger breakpoint — this exception BP stays disarmed until the trigger fires. Sticky by default.") @Nullable Integer triggerBreakpointId,
-        @McpToolParam(required = false, description = "If true, re-disarm this BP after each hit so the next trigger fire re-arms it. Default: false (sticky).") @Nullable Boolean oneShot) {
+        @McpToolParam(required = false, description = "If true, re-disarm this BP after each hit so the next trigger fire re-arms it. Default: false (sticky).") @Nullable Boolean oneShot,
+        @McpToolParam(required = false, description = "If true, force-load the exception class via Class.forName when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Useful for JDK exception classes the application has never referenced (ClassPrepareEvent is not delivered for bootstrap classes, so the deferred path will never activate).") @Nullable Boolean forceLoad) {
         return registerExceptionBreakpointInternal(
             exceptionClass, caught, uncaught,
             /* expression */ null, /* condition */ null,
-            triggerBreakpointId, oneShot);
+            triggerBreakpointId, oneShot, forceLoad);
     }
 
     @McpTool(description = "Set a non-stopping breakpoint that records an EXCEPTION_LOG event for each " +
@@ -2301,8 +2316,11 @@ public class JDWPTools {
         "$exception bound to the thrown object (e.g., \"$exception.getMessage()\"); its result is attached " +
         "to the event. The optional condition is evaluated with the same $exception binding — the log is " +
         "recorded only when the condition is true. Use this for tracing exception flows in long-running " +
-        "services without halting traffic. If the exception class is not yet loaded, the logpoint is " +
-        "deferred and will activate automatically when the JVM loads it.")
+        "services without halting traffic. By default the logpoint is registered passively: if the exception " +
+        "class is not yet loaded the logpoint is deferred via a ClassPrepareRequest and activates on natural " +
+        "load. Pass forceLoad=true when targeting an exception class the application hasn't referenced yet " +
+        "(typically a JDK exception type such as java.sql.SQLException) — accepts the side effects of " +
+        "running <clinit> in the target VM.")
     public String jdwp_set_exception_logpoint(
         @McpToolParam(description = "Exception class name (e.g., 'java.sql.SQLException')") String exceptionClass,
         @McpToolParam(description = "Java expression evaluated on each hit; $exception is bound to the thrown object") String expression,
@@ -2310,7 +2328,8 @@ public class JDWPTools {
         @McpToolParam(required = false, description = "Log caught exceptions (default: true)") @Nullable Boolean caught,
         @McpToolParam(required = false, description = "Log uncaught exceptions (default: true)") @Nullable Boolean uncaught,
         @McpToolParam(required = false, description = "Optional ID of a trigger breakpoint — this logpoint stays disarmed until the trigger fires. Sticky by default.") @Nullable Integer triggerBreakpointId,
-        @McpToolParam(required = false, description = "If true, re-disarm after each hit so the next trigger fire re-arms it. Default: false (sticky).") @Nullable Boolean oneShot) {
+        @McpToolParam(required = false, description = "If true, re-disarm after each hit so the next trigger fire re-arms it. Default: false (sticky).") @Nullable Boolean oneShot,
+        @McpToolParam(required = false, description = "If true, force-load the exception class via Class.forName when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Useful for JDK exception classes the application has never referenced.") @Nullable Boolean forceLoad) {
         if (expression == null || expression.isBlank()) {
             return "Error: expression is required for jdwp_set_exception_logpoint. "
                 + "Use jdwp_set_exception_breakpoint for a suspending exception BP without expression evaluation.";
@@ -2318,7 +2337,7 @@ public class JDWPTools {
         return registerExceptionBreakpointInternal(
             exceptionClass, caught, uncaught,
             expression, condition,
-            triggerBreakpointId, oneShot);
+            triggerBreakpointId, oneShot, forceLoad);
     }
 
     /**
@@ -2335,7 +2354,8 @@ public class JDWPTools {
         String exceptionClass,
         @Nullable Boolean caught, @Nullable Boolean uncaught,
         @Nullable String expression, @Nullable String condition,
-        @Nullable Integer triggerBreakpointId, @Nullable Boolean oneShot) {
+        @Nullable Integer triggerBreakpointId, @Nullable Boolean oneShot,
+        @Nullable Boolean forceLoad) {
         try {
             final boolean effectiveCaught = caught == null || caught;
             final boolean effectiveUncaught = uncaught == null || uncaught;
@@ -2357,8 +2377,13 @@ public class JDWPTools {
             final VirtualMachine vm = jdiService.getVM();
             final EventRequestManager erm = vm.eventRequestManager();
 
-            // Try eager: check classesByName, and if empty, force-load via Class.forName
-            final ReferenceType eagerType = jdiService.findOrForceLoadClass(exceptionClass);
+            // Passive lookup by default; only force-load when the caller opts in. The bootstrap-
+            // class problem (ClassPrepareEvent not delivered for java.*/jdk.* exceptions never
+            // referenced by user code) is the primary forceLoad=true use case.
+            final boolean effectiveForceLoad = forceLoad != null && forceLoad;
+            final ReferenceType eagerType = effectiveForceLoad
+                ? jdiService.findOrForceLoadClass(exceptionClass)
+                : jdiService.findLoadedClass(exceptionClass);
 
             if (eagerType == null) {
                 // Class not loadable yet — defer
@@ -2426,8 +2451,10 @@ public class JDWPTools {
     @McpTool(description = "Set a field watchpoint that suspends the firing thread when the field is read " +
         "(mode='access'), written (mode='modification'), or both. Conditions are evaluated against the firing " +
         "frame with $oldValue, $newValue (modification only), $object (null for static), $fieldName, and $mode " +
-        "bound. If the class is not yet loaded, the watchpoint is deferred and activates automatically. " +
-        "ERROR if the field is ambiguous on the class, missing, or static when objectFilterId is supplied.")
+        "bound. By default the BP is registered passively: if the class is not yet loaded it is deferred via " +
+        "a ClassPrepareRequest and activates on natural load. Pass forceLoad=true to bind immediately and " +
+        "accept the side effects of running <clinit> in the target VM. ERROR if the field is ambiguous on the " +
+        "class, missing, or static when objectFilterId is supplied.")
     public String jdwp_set_field_breakpoint(
         @McpToolParam(description = "Fully-qualified class declaring the field (e.g., 'com.example.Order')") String className,
         @McpToolParam(description = "Field name (must be unambiguous on the class)") String fieldName,
@@ -2436,19 +2463,23 @@ public class JDWPTools {
         @McpToolParam(required = false, description = "Optional thread filter — only fire when this thread (uniqueID) hits the field") @Nullable Long threadFilterId,
         @McpToolParam(required = false, description = "Optional object filter — only fire on the given instance (object ID from jdwp_get_locals/jdwp_get_fields). Must be omitted for static fields.") @Nullable Long objectFilterId,
         @McpToolParam(required = false, description = "Optional ID of a trigger breakpoint — this field BP stays disarmed until the trigger fires. Sticky by default.") @Nullable Integer triggerBreakpointId,
-        @McpToolParam(required = false, description = "If true, re-disarm this BP after each hit so the next trigger fire re-arms it. Default: false (sticky).") @Nullable Boolean oneShot) {
+        @McpToolParam(required = false, description = "If true, re-disarm this BP after each hit so the next trigger fire re-arms it. Default: false (sticky).") @Nullable Boolean oneShot,
+        @McpToolParam(required = false, description = "If true, force-load the declaring class via Class.forName when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Force-load triggers <clinit> and may mask lazy-init / classloader-leak diagnostics — use sparingly.") @Nullable Boolean forceLoad) {
         return registerFieldBreakpointInternal(
             className, fieldName, mode,
             /* expression */ null, condition,
             threadFilterId, objectFilterId,
-            triggerBreakpointId, oneShot);
+            triggerBreakpointId, oneShot, forceLoad);
     }
 
     @McpTool(description = "Set a non-stopping field watchpoint that records a FIELD_LOGPOINT event for each " +
         "access or modification of the field. The expression is evaluated against the firing frame with " +
         "$oldValue, $newValue (modification only), $object (null for static), $fieldName, and $mode bound; " +
         "its result is attached to the event. Optional condition gates whether the log is recorded. " +
-        "Use this to trace state transitions in long-running services without halting traffic.")
+        "Use this to trace state transitions in long-running services without halting traffic. By default the " +
+        "logpoint is registered passively: if the class is not yet loaded it is deferred via a " +
+        "ClassPrepareRequest and activates on natural load. Pass forceLoad=true to bind immediately and " +
+        "accept the side effects of running <clinit> in the target VM.")
     public String jdwp_set_field_logpoint(
         @McpToolParam(description = "Fully-qualified class declaring the field") String className,
         @McpToolParam(description = "Field name (must be unambiguous on the class)") String fieldName,
@@ -2458,7 +2489,8 @@ public class JDWPTools {
         @McpToolParam(required = false, description = "Optional thread filter — only fire when this thread (uniqueID) hits the field") @Nullable Long threadFilterId,
         @McpToolParam(required = false, description = "Optional object filter — only fire on the given instance. Must be omitted for static fields.") @Nullable Long objectFilterId,
         @McpToolParam(required = false, description = "Optional ID of a trigger breakpoint — this logpoint stays disarmed until the trigger fires. Sticky by default.") @Nullable Integer triggerBreakpointId,
-        @McpToolParam(required = false, description = "If true, re-disarm after each hit so the next trigger fire re-arms it. Default: false (sticky).") @Nullable Boolean oneShot) {
+        @McpToolParam(required = false, description = "If true, re-disarm after each hit so the next trigger fire re-arms it. Default: false (sticky).") @Nullable Boolean oneShot,
+        @McpToolParam(required = false, description = "If true, force-load the declaring class via Class.forName when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Force-load triggers <clinit> and may mask lazy-init diagnostics — use sparingly.") @Nullable Boolean forceLoad) {
         if (expression == null || expression.isBlank()) {
             return "Error: expression is required for jdwp_set_field_logpoint. "
                 + "Use jdwp_set_field_breakpoint for a suspending field BP without expression evaluation.";
@@ -2467,7 +2499,7 @@ public class JDWPTools {
             className, fieldName, mode,
             expression, condition,
             threadFilterId, objectFilterId,
-            triggerBreakpointId, oneShot);
+            triggerBreakpointId, oneShot, forceLoad);
     }
 
     /**
@@ -2484,7 +2516,8 @@ public class JDWPTools {
         String className, String fieldName, String mode,
         @Nullable String expression, @Nullable String condition,
         @Nullable Long threadFilterId, @Nullable Long objectFilterId,
-        @Nullable Integer triggerBreakpointId, @Nullable Boolean oneShot) {
+        @Nullable Integer triggerBreakpointId, @Nullable Boolean oneShot,
+        @Nullable Boolean forceLoad) {
         try {
             if (className == null || className.isBlank()) {
                 return "Error: className is required";
@@ -2523,7 +2556,10 @@ public class JDWPTools {
 
             final VirtualMachine vm = jdiService.getVM();
             final EventRequestManager erm = vm.eventRequestManager();
-            final ReferenceType eagerType = jdiService.findOrForceLoadClass(className);
+            final boolean effectiveForceLoad = forceLoad != null && forceLoad;
+            final ReferenceType eagerType = effectiveForceLoad
+                ? jdiService.findOrForceLoadClass(className)
+                : jdiService.findLoadedClass(className);
 
             final String chainInfo = triggerBreakpointId != null
                 ? String.format("\n  Chain: trigger=#%d%s",

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JDWPTools.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JDWPTools.java
@@ -1807,7 +1807,7 @@ public class JDWPTools {
         }
     }
 
-    @McpTool(description = "Set a breakpoint at a specific line in a class. Supports conditional breakpoints. By default the breakpoint is registered passively: if the class is not yet loaded, the BP is deferred via a ClassPrepareRequest and activates when the JVM loads the class on its own — same behaviour as IntelliJ / Eclipse / jdb. Pass forceLoad=true only when you need the breakpoint to bind immediately and accept that loading the class will run its <clinit> (early static init, eager dependency loads, masked lazy-load diagnostics).")
+    @McpTool(description = "Set a breakpoint at a specific line in a class. Supports conditional breakpoints. By default the breakpoint is registered passively: if the class is not yet loaded, the BP is deferred via a ClassPrepareRequest and activates when the JVM loads the class on its own — same behaviour as IntelliJ / Eclipse / jdb. Pass forceLoad=true only when you need the breakpoint to bind immediately and accept that loading the class will run its `<clinit>` (early static init, eager dependency loads, masked lazy-load diagnostics).")
     public String jdwp_set_breakpoint(
         @McpToolParam(description = "Fully qualified class name (e.g. 'com.example.MyClass')") String className,
         @McpToolParam(description = "Line number") int lineNumber,
@@ -1815,7 +1815,7 @@ public class JDWPTools {
         @McpToolParam(required = false, description = "Optional condition — only suspend when this evaluates to true (e.g., 'i > 100')") @Nullable String condition,
         @McpToolParam(required = false, description = "Optional ID of a trigger breakpoint — this BP stays disarmed until the trigger fires. Sticky by default: once armed it stays so unless re-disarmed via jdwp_disarm_until_trigger or oneShot=true.") @Nullable Integer triggerBreakpointId,
         @McpToolParam(required = false, description = "If true, re-disarm this BP after each hit so the next trigger fire re-arms it (IntelliJ-style). Default: false (sticky).") @Nullable Boolean oneShot,
-        @McpToolParam(required = false, description = "If true, force-load the class via Class.forName in the target VM when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Force-load triggers <clinit>, cascades dependent loads, and can mask lazy-init / classloader-leak diagnostics — use sparingly.") @Nullable Boolean forceLoad) {
+        @McpToolParam(required = false, description = "If true, force-load the class via Class.forName in the target VM when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Force-load triggers `<clinit>`, cascades dependent loads, and can mask lazy-init / classloader-leak diagnostics — use sparingly.") @Nullable Boolean forceLoad) {
         // Track the pending ID outside the try so the catch can clean it up if locationsOfLine
         // (or any later step) throws after the pending entry has already been registered.
         Integer pendingIdForCleanup = null;
@@ -1948,13 +1948,13 @@ public class JDWPTools {
         }
     }
 
-    @McpTool(description = "Set a logpoint (non-stopping breakpoint) that evaluates an expression and logs the result without pausing execution. Supports an optional condition — the expression is only logged when the condition evaluates to true. By default the logpoint is registered passively: if the class is not yet loaded, it is deferred via a ClassPrepareRequest and activates on natural load. Pass forceLoad=true to force the class load (runs <clinit>, may mask lazy-init diagnostics).")
+    @McpTool(description = "Set a logpoint (non-stopping breakpoint) that evaluates an expression and logs the result without pausing execution. Supports an optional condition — the expression is only logged when the condition evaluates to true. By default the logpoint is registered passively: if the class is not yet loaded, it is deferred via a ClassPrepareRequest and activates on natural load. Pass forceLoad=true to force the class load (runs `<clinit>`, may mask lazy-init diagnostics).")
     public String jdwp_set_logpoint(
         @McpToolParam(description = "Fully qualified class name") String className,
         @McpToolParam(description = "Line number") int lineNumber,
         @McpToolParam(description = "Java expression to evaluate and log (e.g., '\"x=\" + x', 'order.getTotal()')") String expression,
         @McpToolParam(required = false, description = "Optional condition — only log when this evaluates to true (e.g., 'i > 100')") @Nullable String condition,
-        @McpToolParam(required = false, description = "If true, force-load the class via Class.forName in the target VM when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Force-load triggers <clinit> and can mask lazy-init / classloader-leak diagnostics — use sparingly.") @Nullable Boolean forceLoad) {
+        @McpToolParam(required = false, description = "If true, force-load the class via Class.forName in the target VM when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Force-load triggers `<clinit>` and can mask lazy-init / classloader-leak diagnostics — use sparingly.") @Nullable Boolean forceLoad) {
         // Track the pending ID outside the try so the catch can clean it up if locationsOfLine
         // (or any later step) throws after the pending entry has already been registered.
         Integer pendingIdForCleanup = null;
@@ -2297,7 +2297,7 @@ public class JDWPTools {
         "class is not yet loaded the BP is deferred via a ClassPrepareRequest and activates on natural load. " +
         "Pass forceLoad=true when targeting an exception class the application hasn't referenced yet " +
         "(typically a JDK exception type such as java.sql.SQLException) — accepts the side effects of " +
-        "running <clinit> in the target VM.")
+        "running `<clinit>` in the target VM.")
     public String jdwp_set_exception_breakpoint(
         @McpToolParam(description = "Exception class name (e.g., 'java.lang.NullPointerException', 'java.lang.Exception' for all)") String exceptionClass,
         @McpToolParam(required = false, description = "Break on caught exceptions (default: true)") @Nullable Boolean caught,
@@ -2320,7 +2320,7 @@ public class JDWPTools {
         "class is not yet loaded the logpoint is deferred via a ClassPrepareRequest and activates on natural " +
         "load. Pass forceLoad=true when targeting an exception class the application hasn't referenced yet " +
         "(typically a JDK exception type such as java.sql.SQLException) — accepts the side effects of " +
-        "running <clinit> in the target VM.")
+        "running `<clinit>` in the target VM.")
     public String jdwp_set_exception_logpoint(
         @McpToolParam(description = "Exception class name (e.g., 'java.sql.SQLException')") String exceptionClass,
         @McpToolParam(description = "Java expression evaluated on each hit; $exception is bound to the thrown object") String expression,
@@ -2453,7 +2453,7 @@ public class JDWPTools {
         "frame with $oldValue, $newValue (modification only), $object (null for static), $fieldName, and $mode " +
         "bound. By default the BP is registered passively: if the class is not yet loaded it is deferred via " +
         "a ClassPrepareRequest and activates on natural load. Pass forceLoad=true to bind immediately and " +
-        "accept the side effects of running <clinit> in the target VM. ERROR if the field is ambiguous on the " +
+        "accept the side effects of running `<clinit>` in the target VM. ERROR if the field is ambiguous on the " +
         "class, missing, or static when objectFilterId is supplied.")
     public String jdwp_set_field_breakpoint(
         @McpToolParam(description = "Fully-qualified class declaring the field (e.g., 'com.example.Order')") String className,
@@ -2464,7 +2464,7 @@ public class JDWPTools {
         @McpToolParam(required = false, description = "Optional object filter — only fire on the given instance (object ID from jdwp_get_locals/jdwp_get_fields). Must be omitted for static fields.") @Nullable Long objectFilterId,
         @McpToolParam(required = false, description = "Optional ID of a trigger breakpoint — this field BP stays disarmed until the trigger fires. Sticky by default.") @Nullable Integer triggerBreakpointId,
         @McpToolParam(required = false, description = "If true, re-disarm this BP after each hit so the next trigger fire re-arms it. Default: false (sticky).") @Nullable Boolean oneShot,
-        @McpToolParam(required = false, description = "If true, force-load the declaring class via Class.forName when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Force-load triggers <clinit> and may mask lazy-init / classloader-leak diagnostics — use sparingly.") @Nullable Boolean forceLoad) {
+        @McpToolParam(required = false, description = "If true, force-load the declaring class via Class.forName when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Force-load triggers `<clinit>` and may mask lazy-init / classloader-leak diagnostics — use sparingly.") @Nullable Boolean forceLoad) {
         return registerFieldBreakpointInternal(
             className, fieldName, mode,
             /* expression */ null, condition,
@@ -2479,7 +2479,7 @@ public class JDWPTools {
         "Use this to trace state transitions in long-running services without halting traffic. By default the " +
         "logpoint is registered passively: if the class is not yet loaded it is deferred via a " +
         "ClassPrepareRequest and activates on natural load. Pass forceLoad=true to bind immediately and " +
-        "accept the side effects of running <clinit> in the target VM.")
+        "accept the side effects of running `<clinit>` in the target VM.")
     public String jdwp_set_field_logpoint(
         @McpToolParam(description = "Fully-qualified class declaring the field") String className,
         @McpToolParam(description = "Field name (must be unambiguous on the class)") String fieldName,
@@ -2490,7 +2490,7 @@ public class JDWPTools {
         @McpToolParam(required = false, description = "Optional object filter — only fire on the given instance. Must be omitted for static fields.") @Nullable Long objectFilterId,
         @McpToolParam(required = false, description = "Optional ID of a trigger breakpoint — this logpoint stays disarmed until the trigger fires. Sticky by default.") @Nullable Integer triggerBreakpointId,
         @McpToolParam(required = false, description = "If true, re-disarm after each hit so the next trigger fire re-arms it. Default: false (sticky).") @Nullable Boolean oneShot,
-        @McpToolParam(required = false, description = "If true, force-load the declaring class via Class.forName when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Force-load triggers <clinit> and may mask lazy-init diagnostics — use sparingly.") @Nullable Boolean forceLoad) {
+        @McpToolParam(required = false, description = "If true, force-load the declaring class via Class.forName when it isn't already loaded. Default: false (passive — defer via ClassPrepareRequest). Force-load triggers `<clinit>` and may mask lazy-init diagnostics — use sparingly.") @Nullable Boolean forceLoad) {
         if (expression == null || expression.isBlank()) {
             return "Error: expression is required for jdwp_set_field_logpoint. "
                 + "Use jdwp_set_field_breakpoint for a suspending field BP without expression evaluation.";

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JdiEventListener.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JdiEventListener.java
@@ -41,12 +41,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * death event.
  * <p>
  * Promotion contract: the main listener loop does not call
- * {@link BreakpointTracker#tryPromotePending(JDIConnectionService, ThreadReference)} directly —
- * promotion happens lazily via {@link JDIConnectionService#getVM()} on the next MCP tool call.
- * Logpoint and conditional-BP handlers DO end up calling it indirectly the first time after
- * connect (via {@code configureCompilerClasspath} → {@code discoverClasspath} → {@code getVM}),
- * which is safe because the BP thread is already suspended at a method-invocation event —
- * JDI permits {@code invokeMethod} on threads in that state.
+ * {@link BreakpointTracker#tryPromotePending(JDIConnectionService)} directly — promotion happens
+ * lazily via {@link JDIConnectionService#getVM()} on the next MCP tool call. Logpoint and
+ * conditional-BP handlers DO end up calling it indirectly the first time after connect (via
+ * {@code configureCompilerClasspath} → {@code discoverClasspath} → {@code getVM}); the safety-net
+ * promoter is strictly passive (it never calls {@code invokeMethod} on the target VM), so it is
+ * safe to invoke from any event-thread context.
  * <p>
  * Chain handling: after every BP, exception, or auto-resumed logpoint hit,
  * {@link #applyChainEffectsAfterHit} arms any dependent BPs waiting on the firing BP and

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerExceptionAndMetadataTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerExceptionAndMetadataTest.java
@@ -466,7 +466,7 @@ class BreakpointTrackerExceptionAndMetadataTest {
 
 		@Test
 		void shouldReturnZeroWhenServiceNull() {
-			assertThat(tracker.tryPromotePending(null, null)).isZero();
+			assertThat(tracker.tryPromotePending(null)).isZero();
 		}
 
 		@Test
@@ -474,7 +474,7 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			JDIConnectionService service = mock(JDIConnectionService.class);
 			when(service.getRawVM()).thenReturn(null);
 
-			assertThat(tracker.tryPromotePending(service, null)).isZero();
+			assertThat(tracker.tryPromotePending(service)).isZero();
 		}
 
 		@Test
@@ -485,7 +485,7 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			when(service.getRawVM()).thenReturn(vm);
 			when(vm.eventRequestManager()).thenReturn(erm);
 
-			assertThat(tracker.tryPromotePending(service, null)).isZero();
+			assertThat(tracker.tryPromotePending(service)).isZero();
 		}
 
 		@Test
@@ -499,10 +499,40 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			int id = tracker.registerPendingBreakpoint("com.example.Foo", 42, 2, "ALL");
 			tracker.markPendingFailed(id, "no executable code");
 
-			int promoted = tracker.tryPromotePending(service, null);
+			int promoted = tracker.tryPromotePending(service);
 
 			assertThat(promoted).isZero();
 			assertThat(tracker.getPendingBreakpoint(id)).isNotNull();
+		}
+
+		/**
+		 * Regression guard for GH issue #3: the safety-net promoter is strictly passive — it must
+		 * NEVER invoke {@code findOrForceLoadClass}, because that path triggers {@code Class.forName}
+		 * in the target VM and changes application behaviour the debugger should only observe. The
+		 * promotion path uses {@link JDIConnectionService#findLoadedClass} exclusively; this test
+		 * fails if a regression re-routes any of the three call sites (line, exception, field) back
+		 * to the force-load overloads.
+		 */
+		@Test
+		void shouldNeverCallFindOrForceLoadClassFromSafetyNet() throws Exception {
+			JDIConnectionService service = mock(JDIConnectionService.class);
+			VirtualMachine vm = mock(VirtualMachine.class);
+			EventRequestManager erm = mock(EventRequestManager.class);
+			when(service.getRawVM()).thenReturn(vm);
+			when(vm.eventRequestManager()).thenReturn(erm);
+
+			tracker.registerPendingBreakpoint("com.example.Foo", 42, 2, "ALL");
+			tracker.registerPendingExceptionBreakpoint(
+				ExceptionBreakpointSpec.suspending("com.example.MyException", true, true));
+			tracker.registerPendingFieldBreakpoint(BreakpointTracker.FieldBreakpointSpec.suspending(
+				"com.example.Owner", "field", BreakpointTracker.FieldWatchMode.ACCESS, null, null, null));
+
+			tracker.tryPromotePending(service);
+
+			verify(service, org.mockito.Mockito.never()).findOrForceLoadClass(
+				org.mockito.ArgumentMatchers.anyString());
+			verify(service, org.mockito.Mockito.never()).findOrForceLoadClass(
+				org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any());
 		}
 
 		/**
@@ -520,7 +550,7 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			BreakpointRequest bp = mock(BreakpointRequest.class);
 			when(service.getRawVM()).thenReturn(vm);
 			when(vm.eventRequestManager()).thenReturn(erm);
-			when(service.findOrForceLoadClass(eq("com.example.Foo"), any())).thenReturn(refType);
+			when(service.findLoadedClass(eq("com.example.Foo"))).thenReturn(refType);
 			when(refType.locationsOfLine(42)).thenReturn(java.util.List.of(loc));
 			when(erm.createBreakpointRequest(loc)).thenReturn(bp);
 
@@ -528,7 +558,7 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			int pendingId = tracker.registerPendingBreakpoint("com.example.Foo", 42, 2, "ALL");
 			tracker.registerDependency(pendingId, triggerId, false);
 
-			int promoted = tracker.tryPromotePending(service, null);
+			int promoted = tracker.tryPromotePending(service);
 
 			assertThat(promoted).isEqualTo(1);
 			verify(bp).setEnabled(false);
@@ -548,7 +578,7 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			ExceptionRequest exReq = mock(ExceptionRequest.class);
 			when(service.getRawVM()).thenReturn(vm);
 			when(vm.eventRequestManager()).thenReturn(erm);
-			when(service.findOrForceLoadClass(eq("com.example.MyException"), any())).thenReturn(refType);
+			when(service.findLoadedClass(eq("com.example.MyException"))).thenReturn(refType);
 			when(erm.createExceptionRequest(refType, true, true)).thenReturn(exReq);
 
 			int triggerId = tracker.registerBreakpoint(mock(BreakpointRequest.class));
@@ -556,7 +586,7 @@ class BreakpointTrackerExceptionAndMetadataTest {
 				ExceptionBreakpointSpec.suspending("com.example.MyException", true, true));
 			tracker.registerDependency(pendingId, triggerId, false);
 
-			int promoted = tracker.tryPromotePending(service, null);
+			int promoted = tracker.tryPromotePending(service);
 
 			assertThat(promoted).isEqualTo(1);
 			verify(exReq).setEnabled(false);
@@ -577,13 +607,13 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			BreakpointRequest bp = mock(BreakpointRequest.class);
 			when(service.getRawVM()).thenReturn(vm);
 			when(vm.eventRequestManager()).thenReturn(erm);
-			when(service.findOrForceLoadClass(eq("com.example.Foo"), any())).thenReturn(refType);
+			when(service.findLoadedClass(eq("com.example.Foo"))).thenReturn(refType);
 			when(refType.locationsOfLine(42)).thenReturn(java.util.List.of(loc));
 			when(erm.createBreakpointRequest(loc)).thenReturn(bp);
 
 			tracker.registerPendingBreakpoint("com.example.Foo", 42, 2, "ALL");
 
-			int promoted = tracker.tryPromotePending(service, null);
+			int promoted = tracker.tryPromotePending(service);
 
 			assertThat(promoted).isEqualTo(1);
 			// enable() is called (from the production code itself), but setEnabled(false) must NOT.
@@ -594,8 +624,8 @@ class BreakpointTrackerExceptionAndMetadataTest {
 	/**
 	 * Recheck-race coverage for the {@code tryPromotePending} per-entry recheck branches. The
 	 * worker thread snapshots pending entries under the tracker monitor, releases the monitor for
-	 * the (potentially slow) {@code findOrForceLoadClass} JDI hop, then re-acquires the monitor to
-	 * recheck-then-promote each entry. Three things can have changed during the JDI hop:
+	 * the per-entry {@code findLoadedClass} lookup, then re-acquires the monitor to recheck-then-
+	 * promote each entry. Three things can have changed during the lookup window:
 	 * <ul>
 	 *   <li>another thread removed the pending entry (e.g. user issued {@code jdwp_clear})</li>
 	 *   <li>another thread marked the pending entry failed (e.g. listener path classifier)</li>
@@ -619,16 +649,16 @@ class BreakpointTrackerExceptionAndMetadataTest {
 
 			int pendingId = tracker.registerPendingBreakpoint("com.example.Foo", 42, 2, "ALL");
 
-			// While the worker is parked inside findOrForceLoadClass, another caller removes the
+			// While the worker is mid-lookup inside findLoadedClass, another caller removes the
 			// pending entry. The recheck must observe pendingBreakpointsById.get(id) != pending and
 			// continue without ever calling locationsOfLine / createBreakpointRequest.
-			when(service.findOrForceLoadClass(eq("com.example.Foo"), any()))
+			when(service.findLoadedClass(eq("com.example.Foo")))
 				.thenAnswer(inv -> {
 					tracker.removePendingBreakpoint(pendingId);
 					return refType;
 				});
 
-			int promoted = tracker.tryPromotePending(service, null);
+			int promoted = tracker.tryPromotePending(service);
 
 			assertThat(promoted).isZero();
 			assertThat(tracker.getPendingBreakpoint(pendingId)).isNull();
@@ -647,13 +677,13 @@ class BreakpointTrackerExceptionAndMetadataTest {
 
 			int pendingId = tracker.registerPendingBreakpoint("com.example.Foo", 42, 2, "ALL");
 
-			when(service.findOrForceLoadClass(eq("com.example.Foo"), any()))
+			when(service.findLoadedClass(eq("com.example.Foo")))
 				.thenAnswer(inv -> {
 					tracker.markPendingFailed(pendingId, "concurrent classifier marked failed");
 					return refType;
 				});
 
-			int promoted = tracker.tryPromotePending(service, null);
+			int promoted = tracker.tryPromotePending(service);
 
 			assertThat(promoted).isZero();
 			// Entry stays in the pending map so the failure reason is visible to overview tools.
@@ -679,13 +709,13 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			// own BreakpointRequest. The worker's recheck must observe breakpointsById.containsKey(id)
 			// and skip the entry — otherwise it would overwrite breakpointsById with its own BP and
 			// leave listenerBp armed on the target VM as a ghost without tracker entry.
-			when(service.findOrForceLoadClass(eq("com.example.Foo"), any()))
+			when(service.findLoadedClass(eq("com.example.Foo")))
 				.thenAnswer(inv -> {
 					tracker.promotePendingToActive(pendingId, listenerBp);
 					return refType;
 				});
 
-			int promoted = tracker.tryPromotePending(service, null);
+			int promoted = tracker.tryPromotePending(service);
 
 			assertThat(promoted).isZero();
 			assertThat(tracker.getBreakpoint(pendingId))
@@ -706,13 +736,13 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			int pendingId = tracker.registerPendingExceptionBreakpoint(
 				ExceptionBreakpointSpec.suspending("com.example.MyException", true, true));
 
-			when(service.findOrForceLoadClass(eq("com.example.MyException"), any()))
+			when(service.findLoadedClass(eq("com.example.MyException")))
 				.thenAnswer(inv -> {
 					tracker.removeExceptionBreakpoint(pendingId);
 					return refType;
 				});
 
-			int promoted = tracker.tryPromotePending(service, null);
+			int promoted = tracker.tryPromotePending(service);
 
 			assertThat(promoted).isZero();
 			assertThat(tracker.getAllPendingExceptionBreakpoints()).doesNotContainKey(pendingId);
@@ -733,13 +763,13 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			int pendingId = tracker.registerPendingExceptionBreakpoint(
 				ExceptionBreakpointSpec.suspending("com.example.MyException", true, true));
 
-			when(service.findOrForceLoadClass(eq("com.example.MyException"), any()))
+			when(service.findLoadedClass(eq("com.example.MyException")))
 				.thenAnswer(inv -> {
 					tracker.markPendingExceptionFailed(pendingId, "concurrent classifier marked failed");
 					return refType;
 				});
 
-			int promoted = tracker.tryPromotePending(service, null);
+			int promoted = tracker.tryPromotePending(service);
 
 			assertThat(promoted).isZero();
 			assertThat(tracker.getAllPendingExceptionBreakpoints().get(pendingId).getFailureReason())
@@ -761,13 +791,13 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			int pendingId = tracker.registerPendingExceptionBreakpoint(
 				ExceptionBreakpointSpec.suspending("com.example.MyException", true, true));
 
-			when(service.findOrForceLoadClass(eq("com.example.MyException"), any()))
+			when(service.findLoadedClass(eq("com.example.MyException")))
 				.thenAnswer(inv -> {
 					tracker.promotePendingExceptionToActive(pendingId, listenerExReq);
 					return refType;
 				});
 
-			int promoted = tracker.tryPromotePending(service, null);
+			int promoted = tracker.tryPromotePending(service);
 
 			assertThat(promoted).isZero();
 			assertThat(tracker.getAllExceptionBreakpoints().get(pendingId).getRequest())
@@ -794,12 +824,12 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			ReferenceType refType = mock(ReferenceType.class);
 			when(service.getRawVM()).thenReturn(vm);
 			when(vm.eventRequestManager()).thenReturn(erm);
-			when(service.findOrForceLoadClass(eq("com.example.Foo"), any())).thenReturn(refType);
+			when(service.findLoadedClass(eq("com.example.Foo"))).thenReturn(refType);
 			when(refType.locationsOfLine(42)).thenThrow(new AbsentInformationException("no debug info"));
 
 			int pendingId = tracker.registerPendingBreakpoint("com.example.Foo", 42, 2, "ALL");
 
-			int promoted = tracker.tryPromotePending(service, null);
+			int promoted = tracker.tryPromotePending(service);
 
 			assertThat(promoted).isZero();
 			assertThat(tracker.getPendingBreakpoint(pendingId))
@@ -841,23 +871,23 @@ class BreakpointTrackerExceptionAndMetadataTest {
 			int idC = tracker.registerPendingBreakpoint("com.example.C", 30, 2, "ALL");
 
 			// A: removed under the worker's feet during its JDI invoke.
-			when(service.findOrForceLoadClass(eq("com.example.A"), any()))
+			when(service.findLoadedClass(eq("com.example.A")))
 				.thenAnswer(inv -> {
 					tracker.removePendingBreakpoint(idA);
 					return refTypeA;
 				});
 			// B: promoted by another caller while the worker is parked.
-			when(service.findOrForceLoadClass(eq("com.example.B"), any()))
+			when(service.findLoadedClass(eq("com.example.B")))
 				.thenAnswer(inv -> {
 					tracker.promotePendingToActive(idB, listenerBpB);
 					return refTypeB;
 				});
 			// C: a clean promotion path — survives the race.
-			when(service.findOrForceLoadClass(eq("com.example.C"), any())).thenReturn(refTypeC);
+			when(service.findLoadedClass(eq("com.example.C"))).thenReturn(refTypeC);
 			when(refTypeC.locationsOfLine(30)).thenReturn(List.of(locC));
 			when(erm.createBreakpointRequest(locC)).thenReturn(bpC);
 
-			int promoted = tracker.tryPromotePending(service, null);
+			int promoted = tracker.tryPromotePending(service);
 
 			assertThat(promoted)
 				.as("only entry C was actually promoted by this caller — A and B lost their recheck race")

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerFieldBreakpointTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerFieldBreakpointTest.java
@@ -327,7 +327,7 @@ class BreakpointTrackerFieldBreakpointTest {
 		AccessWatchpointRequest accessReq = mock(AccessWatchpointRequest.class);
 		when(service.getRawVM()).thenReturn(vm);
 		when(vm.eventRequestManager()).thenReturn(erm);
-		when(service.findOrForceLoadClass(eq("com.x.Foo"), any())).thenReturn(refType);
+		when(service.findLoadedClass(eq("com.x.Foo"))).thenReturn(refType);
 		when(refType.allFields()).thenReturn(List.of(field));
 		when(field.name()).thenReturn("bar");
 		when(field.isStatic()).thenReturn(false);
@@ -338,7 +338,7 @@ class BreakpointTrackerFieldBreakpointTest {
 			"com.x.Foo", "bar", BreakpointTracker.FieldWatchMode.BOTH, null, null, null);
 		int id = tracker.registerPendingFieldBreakpoint(spec);
 
-		int promoted = tracker.tryPromotePending(service, null);
+		int promoted = tracker.tryPromotePending(service);
 
 		assertThat(promoted).isZero();
 		// Pending entry stays in the map so it surfaces in jdwp_overview(types="field_breakpoint"), but its
@@ -379,13 +379,13 @@ class BreakpointTrackerFieldBreakpointTest {
 
 		// While the worker is parked, simulate the listener-side promotion: remove the pending
 		// entry and insert the listener's access request under the same synthetic id.
-		when(service.findOrForceLoadClass(eq("com.x.Foo"), any()))
+		when(service.findLoadedClass(eq("com.x.Foo")))
 			.thenAnswer(inv -> {
 				tracker.promotePendingFieldToActive(pendingId, listenerAccessReq, null);
 				return refType;
 			});
 
-		int promoted = tracker.tryPromotePending(service, null);
+		int promoted = tracker.tryPromotePending(service);
 
 		assertThat(promoted)
 			.as("worker must observe that the pending entry is gone and skip its own creation path")
@@ -399,7 +399,7 @@ class BreakpointTrackerFieldBreakpointTest {
 	/**
 	 * Recheck-race coverage for the field BP arm when the pending entry has been marked failed
 	 * (e.g. by a concurrent classifier that detected an ambiguous field) while the worker is
-	 * parked in {@code findOrForceLoadClass}. The worker's recheck observes the non-null
+	 * parked in {@code findLoadedClass}. The worker's recheck observes the non-null
 	 * failure reason and skips creation — both to avoid duplicating the classifier's work and to
 	 * preserve the failure reason for {@code jdwp_overview} rendering.
 	 */
@@ -417,13 +417,13 @@ class BreakpointTrackerFieldBreakpointTest {
 			"com.x.Foo", "bar", BreakpointTracker.FieldWatchMode.ACCESS, null, null, null);
 		int pendingId = tracker.registerPendingFieldBreakpoint(spec);
 
-		when(service.findOrForceLoadClass(eq("com.x.Foo"), any()))
+		when(service.findLoadedClass(eq("com.x.Foo")))
 			.thenAnswer(inv -> {
 				tracker.markPendingFieldFailed(pendingId, "ambiguous field — classifier marked failed");
 				return refType;
 			});
 
-		int promoted = tracker.tryPromotePending(service, null);
+		int promoted = tracker.tryPromotePending(service);
 
 		assertThat(promoted).isZero();
 		assertThat(tracker.getAllPendingFieldBreakpoints().get(pendingId).getFailureReason())

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerPromotionDeadlockTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/BreakpointTrackerPromotionDeadlockTest.java
@@ -3,7 +3,6 @@ package one.edee.mcp.jdwp;
 import com.sun.jdi.Field;
 import com.sun.jdi.Location;
 import com.sun.jdi.ReferenceType;
-import com.sun.jdi.ThreadReference;
 import com.sun.jdi.VirtualMachine;
 import com.sun.jdi.request.AccessWatchpointRequest;
 import com.sun.jdi.request.BreakpointRequest;
@@ -27,19 +26,22 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Regression guard for the deferred-class-load monitor cycle: while a worker thread is parked
- * inside {@link JDIConnectionService#findOrForceLoadClass} (a synchronous JDI invoke that cannot
- * complete until the event listener drains the event queue), the JDI listener thread must still
- * be able to acquire the {@link BreakpointTracker} monitor and finish
- * {@link BreakpointTracker#promotePendingFieldsForClass}. Pre-fix the listener blocks on the
- * monitor held by the worker and the target VM permanently wedges; post-fix the promotion path
- * does its JDI roundtrip with no tracker monitor held, so the listener proceeds immediately.
+ * Regression guard for the monitor-release contract in {@link BreakpointTracker#tryPromotePending}:
+ * the tracker monitor must NOT be held across the per-entry
+ * {@link JDIConnectionService#findLoadedClass} lookup, so a concurrent listener-side
+ * {@link BreakpointTracker#promotePendingFieldsForClass} (which acquires the same monitor) can
+ * proceed in parallel. Pre-fix, the worker held the monitor across the lookup and the listener
+ * blocked on it; post-fix, the listener runs to completion immediately while the worker is mid-
+ * lookup. The simulated lookup uses a latch to keep the worker suspended past the listener's
+ * observation window, mimicking a slow {@code vm.allClasses()} scan or — historically — a parked
+ * {@code Class.forName} invoke. Both scenarios are covered by the same shape: the property under
+ * test is "monitor released across the lookup", not the specific reason the lookup is slow.
  *
- * <p>Three variants cover the three monitor-held-across-invoke call sites in
- * {@code tryPromotePending} — line BP, exception BP, and field BP — so a partial fix that only
- * addresses one path is caught by the other two. Each variant also asserts the post-release
- * behaviour: once the simulated JDI invoke returns, the worker must finish promotion (active
- * entry visible under the same synthetic id) instead of silently no-oping.
+ * <p>Three variants cover the three call sites in {@code tryPromotePending} — line BP, exception
+ * BP, and field BP — so a partial regression that only re-introduces the bug on one path is
+ * caught by the other two. Each variant also asserts the post-release behaviour: once the
+ * simulated lookup returns, the worker must finish promotion (active entry visible under the
+ * same synthetic id) instead of silently no-oping.
  */
 class BreakpointTrackerPromotionDeadlockTest {
 
@@ -132,8 +134,8 @@ class BreakpointTrackerPromotionDeadlockTest {
 	}
 
 	/**
-	 * Recheck-race coverage for the field BP arm: while the worker is parked inside
-	 * {@link JDIConnectionService#findOrForceLoadClass}, the JDI listener calls
+	 * Recheck-race coverage for the field BP arm: while the worker is mid-lookup in
+	 * {@link JDIConnectionService#findLoadedClass}, the JDI listener calls
 	 * {@link BreakpointTracker#promotePendingFieldsForClass} on the same {@code ReferenceType} and
 	 * wins the race. When the worker eventually re-acquires the tracker monitor, its recheck must
 	 * observe that the pending entry has been removed and return 0 promotions instead of double-
@@ -169,7 +171,7 @@ class BreakpointTrackerPromotionDeadlockTest {
 
 		CountDownLatch workerInsideInvoke = new CountDownLatch(1);
 		CountDownLatch releaseWorker = new CountDownLatch(1);
-		when(service.findOrForceLoadClass(eq("com.x.Foo"), any()))
+		when(service.findLoadedClass(eq("com.x.Foo")))
 			.thenAnswer(inv -> {
 				workerInsideInvoke.countDown();
 				if (!releaseWorker.await(WORKER_RELEASE_TIMEOUT_S, TimeUnit.SECONDS)) {
@@ -180,7 +182,7 @@ class BreakpointTrackerPromotionDeadlockTest {
 
 		AtomicBoolean workerSawPromotion = new AtomicBoolean(false);
 		Thread worker = new Thread(() -> {
-			int promoted = tracker.tryPromotePending(service, null);
+			int promoted = tracker.tryPromotePending(service);
 			workerSawPromotion.set(promoted > 0);
 		}, "field-recheck-race-worker");
 		worker.setDaemon(true);
@@ -211,10 +213,11 @@ class BreakpointTrackerPromotionDeadlockTest {
 	/**
 	 * Guards the outer-monitor decoupling between {@link JDIConnectionService} and
 	 * {@link BreakpointTracker#tryPromotePending}: {@code JDIConnectionService.getVM()} must NOT
-	 * hold the service monitor across the call to {@code tryPromotePending}, because that path can
-	 * park inside a JDI {@code invokeMethod} (force-loading a deferred class) for the duration of
-	 * the target-VM round-trip. Holding the monitor across that window would block every other
-	 * {@code getVM()} caller — and thus every other MCP tool call — until the invoke returns.
+	 * hold the service monitor across the call to {@code tryPromotePending}, because the promotion
+	 * path can stall for a while (the per-entry passive class lookup walks
+	 * {@code vm.allClasses()} which is O(loaded-classes) on the target VM). Holding the monitor
+	 * across that window would block every other {@code getVM()} caller — and thus every other
+	 * MCP tool call — until the slow lookup returns.
 	 *
 	 * <p>The connect / auto-reconnect work still runs under the monitor; only the opportunistic
 	 * promotion call is moved outside. A second {@code getVM()} caller must therefore make progress
@@ -233,8 +236,7 @@ class BreakpointTrackerPromotionDeadlockTest {
 
 		BreakpointTracker blockingTracker = new BreakpointTracker() {
 			@Override
-			public int tryPromotePending(@Nullable JDIConnectionService jdiService,
-			                             @Nullable ThreadReference preferredThread) {
+			public int tryPromotePending(@Nullable JDIConnectionService jdiService) {
 				workerInsideInvoke.countDown();
 				try {
 					if (!releaseWorker.await(WORKER_RELEASE_TIMEOUT_S, TimeUnit.SECONDS)) {
@@ -302,11 +304,11 @@ class BreakpointTrackerPromotionDeadlockTest {
 	}
 
 	/**
-	 * Drives the worker into a simulated parked-JDI-invoke and observes whether the listener-side
-	 * monitor acquire can make progress. Pre-fix the listener blocks on the tracker monitor held
-	 * by the worker and stays alive past {@link #LISTENER_OBSERVATION_WINDOW_MS}; post-fix the
-	 * listener completes immediately and the assertion below passes. Also asserts both threads
-	 * terminate cleanly after the release latch.
+	 * Drives the worker into a simulated slow per-entry lookup and observes whether the listener-
+	 * side monitor acquire can make progress. Pre-fix the listener blocks on the tracker monitor
+	 * held by the worker and stays alive past {@link #LISTENER_OBSERVATION_WINDOW_MS}; post-fix
+	 * the listener completes immediately and the assertion below passes. Also asserts both
+	 * threads terminate cleanly after the release latch.
 	 */
 	private static void runDeadlockProbe(BreakpointTracker tracker, JDIConnectionService service,
 	                                     VirtualMachine vm, EventRequestManager erm,
@@ -314,10 +316,11 @@ class BreakpointTrackerPromotionDeadlockTest {
 		CountDownLatch workerInsideInvoke = new CountDownLatch(1);
 		CountDownLatch releaseWorker = new CountDownLatch(1);
 
-		// Simulate the parked JDI invoke: signal that the worker is "inside JDI", then block
-		// until the listener side has had its chance to run. The fix moves this call outside the
-		// BreakpointTracker monitor, so the listener can acquire the monitor while we wait here.
-		when(service.findOrForceLoadClass(eq("com.x.Foo"), any()))
+		// Simulate a slow per-entry lookup: signal that the worker is "inside the lookup", then
+		// block until the listener side has had its chance to run. The contract under test is that
+		// the call happens OUTSIDE the BreakpointTracker monitor, so the listener can acquire the
+		// monitor while we wait here.
+		when(service.findLoadedClass(eq("com.x.Foo")))
 			.thenAnswer(inv -> {
 				workerInsideInvoke.countDown();
 				if (!releaseWorker.await(WORKER_RELEASE_TIMEOUT_S, TimeUnit.SECONDS)) {
@@ -326,7 +329,7 @@ class BreakpointTrackerPromotionDeadlockTest {
 				return refType;
 			});
 
-		Thread worker = new Thread(() -> tracker.tryPromotePending(service, null), "deadlock-probe-worker");
+		Thread worker = new Thread(() -> tracker.tryPromotePending(service), "deadlock-probe-worker");
 		worker.setDaemon(true);
 		worker.start();
 
@@ -355,7 +358,7 @@ class BreakpointTrackerPromotionDeadlockTest {
 
 		assertThat(listenerBlockedOnMonitor)
 			.as("promotePendingFieldsForClass must not be BLOCKED on the BreakpointTracker monitor "
-				+ "while a worker is parked inside findOrForceLoadClass — listener state observed: %s",
+				+ "while a worker is mid-lookup inside findLoadedClass — listener state observed: %s",
 				listenerState)
 			.isFalse();
 		assertThat(worker.isAlive())

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsBugCaptureTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsBugCaptureTest.java
@@ -117,7 +117,7 @@ class JDWPToolsBugCaptureTest {
 		when(vm.eventRequestManager()).thenReturn(erm);
 		when(erm.createClassPrepareRequest()).thenReturn(cpr);
 		// First lookup returns nothing → enter the pending branch
-		when(jdiService.findOrForceLoadClass("com.example.MyClass")).thenReturn(null);
+		when(jdiService.findLoadedClass("com.example.MyClass")).thenReturn(null);
 		// The recheck inside the pending branch finds the class — race window
 		when(vm.classesByName("com.example.MyClass")).thenReturn(List.of(refType));
 		// locationsOfLine throws AbsentInformationException
@@ -126,7 +126,7 @@ class JDWPToolsBugCaptureTest {
 		when(breakpointTracker.registerPendingBreakpoint(anyString(), anyInt(), anyInt(), anyString()))
 			.thenReturn(99);
 
-		String result = tools.jdwp_set_breakpoint("com.example.MyClass", 42, "all", null, null, null);
+		String result = tools.jdwp_set_breakpoint("com.example.MyClass", 42, "all", null, null, null, null);
 
 		// User-facing error message preserved
 		assertThat(result).startsWith("Error:");
@@ -149,13 +149,13 @@ class JDWPToolsBugCaptureTest {
 		when(jdiService.getVM()).thenReturn(vm);
 		when(vm.eventRequestManager()).thenReturn(erm);
 		when(erm.createClassPrepareRequest()).thenReturn(cpr);
-		when(jdiService.findOrForceLoadClass("com.example.MyClass")).thenReturn(null);
+		when(jdiService.findLoadedClass("com.example.MyClass")).thenReturn(null);
 		when(vm.classesByName("com.example.MyClass")).thenReturn(List.of(refType));
 		when(refType.locationsOfLine(42)).thenThrow(new AbsentInformationException());
 		when(breakpointTracker.registerPendingBreakpoint(anyString(), anyInt(), anyInt(), anyString()))
 			.thenReturn(77);
 
-		String result = tools.jdwp_set_logpoint("com.example.MyClass", 42, "\"x=\" + x", null);
+		String result = tools.jdwp_set_logpoint("com.example.MyClass", 42, "\"x=\" + x", null, null);
 
 		assertThat(result).startsWith("Error:");
 		assertThat(result).contains("debug info");

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsChainToolsTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsChainToolsTest.java
@@ -305,7 +305,7 @@ class JDWPToolsChainToolsTest {
 		@Test
 		@DisplayName("rejects an unknown trigger")
 		void shouldRejectSetBreakpointWithUnknownTrigger() throws Exception {
-			String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, 999, false);
+			String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, 999, false, null);
 
 			assertThat(result).startsWith("Error:").contains("Trigger breakpoint #999");
 		}
@@ -314,11 +314,11 @@ class JDWPToolsChainToolsTest {
 		@DisplayName("accepts a pending trigger when setting a new breakpoint")
 		void shouldAcceptPendingTriggerWhenSettingBreakpoint() throws Exception {
 			int pendingTriggerId = tracker.registerPendingBreakpoint("com.example.Trigger", 10, 2, "ALL");
-			when(jdiService.findOrForceLoadClass("com.example.Foo")).thenReturn(null);
+			when(jdiService.findLoadedClass("com.example.Foo")).thenReturn(null);
 			when(vm.classesByName("com.example.Foo")).thenReturn(List.of());
 			when(erm.createClassPrepareRequest()).thenReturn(mock(com.sun.jdi.request.ClassPrepareRequest.class));
 
-			String result = tools.jdwp_set_breakpoint("com.example.Foo", 99, "all", null, pendingTriggerId, false);
+			String result = tools.jdwp_set_breakpoint("com.example.Foo", 99, "all", null, pendingTriggerId, false, null);
 
 			assertThat(result).doesNotStartWith("Error");
 			assertThat(result).contains("chain: trigger=#" + pendingTriggerId);
@@ -330,13 +330,13 @@ class JDWPToolsChainToolsTest {
 			BreakpointRequest createdBp = mock(BreakpointRequest.class);
 			ReferenceType refType = mock(ReferenceType.class);
 			Location loc = mock(Location.class);
-			when(jdiService.findOrForceLoadClass("com.example.Foo")).thenReturn(refType);
+			when(jdiService.findLoadedClass("com.example.Foo")).thenReturn(refType);
 			when(refType.locationsOfLine(10)).thenReturn(List.of(loc));
 			when(erm.createBreakpointRequest(loc)).thenReturn(createdBp);
 
 			int triggerId = tracker.registerBreakpoint(mock(BreakpointRequest.class));
 
-			String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, triggerId, true);
+			String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, triggerId, true, null);
 
 			assertThat(result).contains("chain: trigger=#" + triggerId)
 				.contains("one-shot");
@@ -345,13 +345,13 @@ class JDWPToolsChainToolsTest {
 		@Test
 		@DisplayName("embeds chain info in the pending breakpoint response")
 		void shouldEmbedChainInfoInPendingBreakpointResponse() throws Exception {
-			when(jdiService.findOrForceLoadClass("com.example.Foo")).thenReturn(null);
+			when(jdiService.findLoadedClass("com.example.Foo")).thenReturn(null);
 			when(vm.classesByName("com.example.Foo")).thenReturn(List.of());
 			when(erm.createClassPrepareRequest()).thenReturn(mock(com.sun.jdi.request.ClassPrepareRequest.class));
 
 			int triggerId = tracker.registerBreakpoint(mock(BreakpointRequest.class));
 
-			String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, triggerId, false);
+			String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, triggerId, false, null);
 
 			assertThat(result).contains("deferred")
 				.contains("chain: trigger=#" + triggerId)
@@ -364,13 +364,13 @@ class JDWPToolsChainToolsTest {
 			BreakpointRequest createdBp = mock(BreakpointRequest.class);
 			ReferenceType refType = mock(ReferenceType.class);
 			Location loc = mock(Location.class);
-			when(jdiService.findOrForceLoadClass("com.example.Foo")).thenReturn(refType);
+			when(jdiService.findLoadedClass("com.example.Foo")).thenReturn(refType);
 			when(refType.locationsOfLine(10)).thenReturn(List.of(loc));
 			when(erm.createBreakpointRequest(loc)).thenReturn(createdBp);
 
 			int triggerId = tracker.registerBreakpoint(mock(BreakpointRequest.class));
 
-			tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, triggerId, false);
+			tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, triggerId, false, null);
 
 			// The request must NEVER be enabled while chained — neither setEnabled(true) nor the
 			// convenience enable() may be called. JDI delivers events the instant a request is
@@ -399,11 +399,11 @@ class JDWPToolsChainToolsTest {
 			BreakpointRequest createdBp = mock(BreakpointRequest.class);
 			ReferenceType refType = mock(ReferenceType.class);
 			Location loc = mock(Location.class);
-			when(jdiService.findOrForceLoadClass("com.example.Foo")).thenReturn(refType);
+			when(jdiService.findLoadedClass("com.example.Foo")).thenReturn(refType);
 			when(refType.locationsOfLine(10)).thenReturn(List.of(loc));
 			when(erm.createBreakpointRequest(loc)).thenReturn(createdBp);
 
-			tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, null, false);
+			tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, null, false, null);
 
 			org.mockito.InOrder inOrder = org.mockito.Mockito.inOrder(createdBp);
 			inOrder.verify(createdBp).setSuspendPolicy(EventRequest.SUSPEND_ALL);
@@ -419,7 +419,7 @@ class JDWPToolsChainToolsTest {
 		@DisplayName("rejects an unknown trigger")
 		void shouldRejectExceptionBpWithUnknownTrigger() throws Exception {
 			String result = tools.jdwp_set_exception_breakpoint(
-				"java.lang.RuntimeException", null, null, 999, false);
+				"java.lang.RuntimeException", null, null, 999, false, null);
 
 			assertThat(result).startsWith("Error:").contains("Trigger breakpoint #999");
 		}
@@ -429,13 +429,13 @@ class JDWPToolsChainToolsTest {
 		void shouldEmbedChainInfoInExceptionBreakpointResponse() throws Exception {
 			ReferenceType refType = mock(ReferenceType.class);
 			ExceptionRequest exReq = mock(ExceptionRequest.class);
-			when(jdiService.findOrForceLoadClass("java.lang.RuntimeException")).thenReturn(refType);
+			when(jdiService.findLoadedClass("java.lang.RuntimeException")).thenReturn(refType);
 			when(erm.createExceptionRequest(refType, true, true)).thenReturn(exReq);
 
 			int triggerId = tracker.registerBreakpoint(mock(BreakpointRequest.class));
 
 			String result = tools.jdwp_set_exception_breakpoint(
-				"java.lang.RuntimeException", null, null, triggerId, false);
+				"java.lang.RuntimeException", null, null, triggerId, false, null);
 
 			assertThat(result).contains("Chain: trigger=#" + triggerId)
 				.contains("sticky");
@@ -446,13 +446,13 @@ class JDWPToolsChainToolsTest {
 		void shouldDisableActiveExceptionRequestWhenChained() throws Exception {
 			ReferenceType refType = mock(ReferenceType.class);
 			ExceptionRequest exReq = mock(ExceptionRequest.class);
-			when(jdiService.findOrForceLoadClass("java.lang.RuntimeException")).thenReturn(refType);
+			when(jdiService.findLoadedClass("java.lang.RuntimeException")).thenReturn(refType);
 			when(erm.createExceptionRequest(refType, true, true)).thenReturn(exReq);
 
 			int triggerId = tracker.registerBreakpoint(mock(BreakpointRequest.class));
 
 			tools.jdwp_set_exception_breakpoint(
-				"java.lang.RuntimeException", null, null, triggerId, false);
+				"java.lang.RuntimeException", null, null, triggerId, false, null);
 
 			// The exception request must never be enabled while a chain is wired up — same race
 			// window as the line-BP variant above.

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsFieldBreakpointTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsFieldBreakpointTest.java
@@ -65,7 +65,7 @@ class JDWPToolsFieldBreakpointTest {
 		when(erm.createAccessWatchpointRequest(refType.allFields().get(0))).thenReturn(req);
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Foo", "counter", "access", null, null, null, null, null);
+			"com.Foo", "counter", "access", null, null, null, null, null, null);
 
 		assertThat(result).startsWith("Field breakpoint set");
 		assertThat(result).contains("com.Foo").contains("counter")
@@ -84,7 +84,7 @@ class JDWPToolsFieldBreakpointTest {
 		when(erm.createModificationWatchpointRequest(field)).thenReturn(modReq);
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Foo", "counter", "BOTH", null, null, null, null, null);
+			"com.Foo", "counter", "BOTH", null, null, null, null, null, null);
 
 		assertThat(result).startsWith("Field breakpoint set").contains("Mode: both");
 		verify(erm).createAccessWatchpointRequest(field);
@@ -97,11 +97,11 @@ class JDWPToolsFieldBreakpointTest {
 	@DisplayName("deferred path — registers a ClassPrepareRequest when the class is unloaded")
 	void shouldDeferWhenClassIsUnloaded() {
 		final ClassPrepareRequest cpr = mock(ClassPrepareRequest.class);
-		when(jdiService.findOrForceLoadClass("com.NotLoaded")).thenReturn(null);
+		when(jdiService.findLoadedClass("com.NotLoaded")).thenReturn(null);
 		when(erm.createClassPrepareRequest()).thenReturn(cpr);
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.NotLoaded", "value", "modification", null, null, null, null, null);
+			"com.NotLoaded", "value", "modification", null, null, null, null, null, null);
 
 		assertThat(result).startsWith("Field breakpoint deferred")
 			.contains("com.NotLoaded").contains("value")
@@ -119,10 +119,10 @@ class JDWPToolsFieldBreakpointTest {
 		when(f1.name()).thenReturn("counter");
 		when(f2.name()).thenReturn("counter");
 		when(refType.allFields()).thenReturn(List.of(f1, f2));
-		when(jdiService.findOrForceLoadClass("com.Ambig")).thenReturn(refType);
+		when(jdiService.findLoadedClass("com.Ambig")).thenReturn(refType);
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Ambig", "counter", "access", null, null, null, null, null);
+			"com.Ambig", "counter", "access", null, null, null, null, null, null);
 
 		assertThat(result).startsWith("Error:").contains("ambiguous");
 	}
@@ -132,10 +132,10 @@ class JDWPToolsFieldBreakpointTest {
 	void shouldRejectMissingField() {
 		final ReferenceType refType = mock(ReferenceType.class);
 		when(refType.allFields()).thenReturn(List.of());
-		when(jdiService.findOrForceLoadClass("com.Foo")).thenReturn(refType);
+		when(jdiService.findLoadedClass("com.Foo")).thenReturn(refType);
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Foo", "missing", "access", null, null, null, null, null);
+			"com.Foo", "missing", "access", null, null, null, null, null, null);
 
 		assertThat(result).startsWith("Error:").contains("not found");
 	}
@@ -146,7 +146,7 @@ class JDWPToolsFieldBreakpointTest {
 		mockClassWithField("com.Foo", "instances", /* isStatic */ true);
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Foo", "instances", "modification", null, null, 42L, null, null);
+			"com.Foo", "instances", "modification", null, null, 42L, null, null, null);
 
 		assertThat(result).startsWith("Error:").contains("static").contains("objectFilterId");
 	}
@@ -155,7 +155,7 @@ class JDWPToolsFieldBreakpointTest {
 	@DisplayName("invalid mode — hard error")
 	void shouldRejectInvalidMode() {
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Foo", "counter", "sideways", null, null, null, null, null);
+			"com.Foo", "counter", "sideways", null, null, null, null, null, null);
 
 		assertThat(result).startsWith("Error:").contains("invalid mode").contains("sideways");
 	}
@@ -164,7 +164,7 @@ class JDWPToolsFieldBreakpointTest {
 	@DisplayName("unknown trigger BP id — hard error before touching the VM")
 	void shouldRejectUnknownTrigger() {
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Foo", "counter", "access", null, null, null, 999, null);
+			"com.Foo", "counter", "access", null, null, null, 999, null, null);
 
 		assertThat(result).startsWith("Error:").contains("Trigger breakpoint #999");
 	}
@@ -178,7 +178,7 @@ class JDWPToolsFieldBreakpointTest {
 		final int triggerId = tracker.registerBreakpoint(mock(BreakpointRequest.class));
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Foo", "counter", "access", null, null, null, triggerId, true);
+			"com.Foo", "counter", "access", null, null, null, triggerId, true, null);
 
 		assertThat(result).contains("Chain: trigger=#" + triggerId).contains("one-shot");
 		// Chained BPs stay disarmed until the trigger fires — must NOT have been enabled.
@@ -189,7 +189,7 @@ class JDWPToolsFieldBreakpointTest {
 	@DisplayName("jdwp_set_field_logpoint without expression — hard error")
 	void shouldRejectFieldLogpointWithoutExpression() {
 		final String result = tools.jdwp_set_field_logpoint(
-			"com.Foo", "counter", "access", "", null, null, null, null, null);
+			"com.Foo", "counter", "access", "", null, null, null, null, null, null);
 
 		assertThat(result).startsWith("Error:").contains("expression is required");
 	}
@@ -203,7 +203,7 @@ class JDWPToolsFieldBreakpointTest {
 
 		final String result = tools.jdwp_set_field_logpoint(
 			"com.Foo", "ttl", "modification", "$oldValue + \" -> \" + $newValue",
-			null, null, null, null, null);
+			null, null, null, null, null, null);
 
 		assertThat(result).startsWith("Field breakpoint set")
 			.contains("log-only")
@@ -278,7 +278,7 @@ class JDWPToolsFieldBreakpointTest {
 		when(vm.allThreads()).thenReturn(List.of(thread));
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Foo", "counter", "access", null, 7L, null, null, null);
+			"com.Foo", "counter", "access", null, 7L, null, null, null, null);
 
 		assertThat(result).startsWith("Field breakpoint set").contains("Filters: thread=7");
 		verify(req).addThreadFilter(thread);
@@ -293,7 +293,7 @@ class JDWPToolsFieldBreakpointTest {
 		when(vm.allThreads()).thenReturn(List.of()); // no live threads → thread #999 cannot be found
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Foo", "counter", "access", null, 999L, null, null, null);
+			"com.Foo", "counter", "access", null, 999L, null, null, null, null);
 
 		assertThat(result).startsWith("Error: failed to create field watchpoint")
 			.contains("Thread #999 no longer alive");
@@ -311,7 +311,7 @@ class JDWPToolsFieldBreakpointTest {
 		when(jdiService.getCachedObject(42L)).thenReturn(instance);
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Foo", "balance", "modification", null, null, 42L, null, null);
+			"com.Foo", "balance", "modification", null, null, 42L, null, null, null);
 
 		assertThat(result).startsWith("Field breakpoint set").contains("object=42");
 		verify(req).addInstanceFilter(instance);
@@ -326,7 +326,7 @@ class JDWPToolsFieldBreakpointTest {
 		when(jdiService.getCachedObject(999L)).thenReturn(null);
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Foo", "balance", "modification", null, null, 999L, null, null);
+			"com.Foo", "balance", "modification", null, null, 999L, null, null, null);
 
 		assertThat(result).startsWith("Error: failed to create field watchpoint")
 			.contains("Object #999 no longer in cache");
@@ -343,7 +343,7 @@ class JDWPToolsFieldBreakpointTest {
 			.thenThrow(new RuntimeException("vm capacity exceeded"));
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Foo", "counter", "both", null, null, null, null, null);
+			"com.Foo", "counter", "both", null, null, null, null, null, null);
 
 		assertThat(result).startsWith("Error: failed to create field watchpoint")
 			.contains("vm capacity exceeded");
@@ -371,7 +371,7 @@ class JDWPToolsFieldBreakpointTest {
 			.thenReturn(mock(ModificationWatchpointRequest.class));
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Foo", "counter", input, null, null, null, null, null);
+			"com.Foo", "counter", input, null, null, null, null, null, null);
 
 		assertThat(result).startsWith("Field breakpoint set").contains("Mode: " + canonical);
 	}
@@ -449,11 +449,11 @@ class JDWPToolsFieldBreakpointTest {
 	@DisplayName("deferred field BP with objectFilterId surfaces a Note about deferred static check")
 	void shouldSurfaceDeferredObjectFilterWarning() {
 		final ClassPrepareRequest cpr = mock(ClassPrepareRequest.class);
-		when(jdiService.findOrForceLoadClass("com.Later")).thenReturn(null);
+		when(jdiService.findLoadedClass("com.Later")).thenReturn(null);
 		when(erm.createClassPrepareRequest()).thenReturn(cpr);
 
 		final String result = tools.jdwp_set_field_breakpoint(
-			"com.Later", "balance", "modification", null, null, 42L, null, null);
+			"com.Later", "balance", "modification", null, null, 42L, null, null, null);
 
 		assertThat(result).startsWith("Field breakpoint deferred")
 			.contains("Note: objectFilterId is set")
@@ -464,7 +464,7 @@ class JDWPToolsFieldBreakpointTest {
 
 	/**
 	 * Builds a {@link ReferenceType} mock for {@code className} carrying exactly one {@link Field}
-	 * named {@code fieldName}. Wires {@code jdiService.findOrForceLoadClass(className)} to return
+	 * named {@code fieldName}. Wires {@code jdiService.findLoadedClass(className)} to return
 	 * the type so the eager path under test hits the field-resolution branch.
 	 */
 	private ReferenceType mockClassWithField(String className, String fieldName, boolean isStatic) {
@@ -473,7 +473,7 @@ class JDWPToolsFieldBreakpointTest {
 		when(field.name()).thenReturn(fieldName);
 		when(field.isStatic()).thenReturn(isStatic);
 		when(refType.allFields()).thenReturn(List.of(field));
-		when(jdiService.findOrForceLoadClass(className)).thenReturn(refType);
+		when(jdiService.findLoadedClass(className)).thenReturn(refType);
 		return refType;
 	}
 

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsNullParamDefaultsTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsNullParamDefaultsTest.java
@@ -96,7 +96,7 @@ class JDWPToolsNullParamDefaultsTest {
 			// path and trivially match).
 			when(jdiService.getVM()).thenThrow(new IllegalStateException("Not connected"));
 
-			String result = tools.jdwp_set_exception_breakpoint("com.example.MyException", null, null, null, null);
+			String result = tools.jdwp_set_exception_breakpoint("com.example.MyException", null, null, null, null, null);
 			// Should get an error about connection, not a NullPointerException on auto-unboxing.
 			assertThat(result).contains("Error");
 			assertThat(result).doesNotContain("NullPointerException");

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsSetBreakpointTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsSetBreakpointTest.java
@@ -57,7 +57,7 @@ class JDWPToolsSetBreakpointTest {
 		final ReferenceType refType = mock(ReferenceType.class);
 		final Location loc = mock(Location.class);
 		final BreakpointRequest req = mock(BreakpointRequest.class);
-		when(jdiService.findOrForceLoadClass(className)).thenReturn(refType);
+		when(jdiService.findLoadedClass(className)).thenReturn(refType);
 		when(refType.locationsOfLine(line)).thenReturn(List.of(loc));
 		when(erm.createBreakpointRequest(loc)).thenReturn(req);
 		return req;
@@ -72,7 +72,7 @@ class JDWPToolsSetBreakpointTest {
 		void shouldUseSuspendAllForExplicitAll() throws Exception {
 			final BreakpointRequest req = wireEagerSet("com.example.Foo", 10);
 
-			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, null, null);
+			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, null, null, null);
 
 			assertThat(result).contains("suspend: all");
 			verify(req).setSuspendPolicy(EventRequest.SUSPEND_ALL);
@@ -83,7 +83,7 @@ class JDWPToolsSetBreakpointTest {
 		void shouldDefaultToSuspendAllWhenNull() throws Exception {
 			final BreakpointRequest req = wireEagerSet("com.example.Foo", 10);
 
-			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, null, null, null, null);
+			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, null, null, null, null, null);
 
 			assertThat(result).contains("suspend: all");
 			verify(req).setSuspendPolicy(EventRequest.SUSPEND_ALL);
@@ -94,7 +94,7 @@ class JDWPToolsSetBreakpointTest {
 		void shouldUseSuspendEventThreadForThread() throws Exception {
 			final BreakpointRequest req = wireEagerSet("com.example.Foo", 10);
 
-			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "thread", null, null, null);
+			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "thread", null, null, null, null);
 
 			assertThat(result).contains("suspend: thread");
 			verify(req).setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD);
@@ -105,7 +105,7 @@ class JDWPToolsSetBreakpointTest {
 		void shouldUseSuspendNoneForNone() throws Exception {
 			final BreakpointRequest req = wireEagerSet("com.example.Foo", 10);
 
-			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "none", null, null, null);
+			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "none", null, null, null, null);
 
 			assertThat(result).contains("suspend: none");
 			verify(req).setSuspendPolicy(EventRequest.SUSPEND_NONE);
@@ -116,7 +116,7 @@ class JDWPToolsSetBreakpointTest {
 		void shouldAcceptUppercasePolicy() throws Exception {
 			final BreakpointRequest req = wireEagerSet("com.example.Foo", 10);
 
-			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "ALL", null, null, null);
+			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "ALL", null, null, null, null);
 
 			assertThat(result).contains("suspend: all");
 			verify(req).setSuspendPolicy(EventRequest.SUSPEND_ALL);
@@ -125,7 +125,7 @@ class JDWPToolsSetBreakpointTest {
 		@Test
 		@DisplayName("unknown policy returns an actionable error")
 		void shouldRejectInvalidSuspendPolicy() throws Exception {
-			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "bogus", null, null, null);
+			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "bogus", null, null, null, null);
 
 			assertThat(result).startsWith("Error:").contains("Invalid suspend policy 'bogus'");
 		}
@@ -140,7 +140,7 @@ class JDWPToolsSetBreakpointTest {
 		void shouldSetBreakpointEagerlyWhenClassIsLoaded() throws Exception {
 			final BreakpointRequest req = wireEagerSet("com.example.Foo", 10);
 
-			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, null, null);
+			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, null, null, null);
 
 			assertThat(result).startsWith("Breakpoint set at com.example.Foo:10");
 			// Unchained BP must be enabled as the last step.
@@ -152,15 +152,57 @@ class JDWPToolsSetBreakpointTest {
 		@DisplayName("deferred path — registers a ClassPrepareRequest when class not yet loaded")
 		void shouldDeferWhenClassNotLoaded() throws Exception {
 			final ClassPrepareRequest cpr = mock(ClassPrepareRequest.class);
-			when(jdiService.findOrForceLoadClass("com.example.Foo")).thenReturn(null);
+			when(jdiService.findLoadedClass("com.example.Foo")).thenReturn(null);
 			when(vm.classesByName("com.example.Foo")).thenReturn(List.of());
 			when(erm.createClassPrepareRequest()).thenReturn(cpr);
 
-			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, null, null);
+			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, null, null, null);
 
 			assertThat(result).startsWith("Breakpoint deferred for com.example.Foo:10");
 			verify(cpr).addClassFilter("com.example.Foo");
 			verify(cpr).enable();
+		}
+
+		/**
+		 * Default registration must not trigger {@code Class.forName} in the target VM — the whole
+		 * point of GH issue #3 is that the debugger observes class loads rather than causing them.
+		 * Asserts via Mockito {@code never()} so a regression that re-introduces an eager force-load
+		 * call on the default path fails this test deterministically.
+		 */
+		@Test
+		@DisplayName("default registration never calls findOrForceLoadClass")
+		void shouldNeverForceLoadOnDefaultRegistration() throws Exception {
+			when(jdiService.findLoadedClass("com.example.Foo")).thenReturn(null);
+			when(vm.classesByName("com.example.Foo")).thenReturn(List.of());
+			when(erm.createClassPrepareRequest()).thenReturn(mock(ClassPrepareRequest.class));
+
+			tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, null, null, null);
+
+			verify(jdiService, org.mockito.Mockito.never()).findOrForceLoadClass(org.mockito.ArgumentMatchers.anyString());
+			verify(jdiService, org.mockito.Mockito.never()).findOrForceLoadClass(
+				org.mockito.ArgumentMatchers.anyString(), org.mockito.ArgumentMatchers.any());
+		}
+
+		/**
+		 * Opt-in path: with {@code forceLoad=true} the tool routes to
+		 * {@link JDIConnectionService#findOrForceLoadClass} so the caller can accept the side
+		 * effects of running {@code <clinit>} in the target VM in exchange for an immediate bind.
+		 */
+		@Test
+		@DisplayName("forceLoad=true routes to findOrForceLoadClass")
+		void shouldRouteToForceLoadWhenForceLoadTrue() throws Exception {
+			final ReferenceType refType = mock(ReferenceType.class);
+			final Location loc = mock(Location.class);
+			final BreakpointRequest req = mock(BreakpointRequest.class);
+			when(jdiService.findOrForceLoadClass("com.example.Foo")).thenReturn(refType);
+			when(refType.locationsOfLine(10)).thenReturn(List.of(loc));
+			when(erm.createBreakpointRequest(loc)).thenReturn(req);
+
+			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", null, null, null, true);
+
+			assertThat(result).startsWith("Breakpoint set at com.example.Foo:10");
+			verify(jdiService).findOrForceLoadClass("com.example.Foo");
+			verify(jdiService, org.mockito.Mockito.never()).findLoadedClass(org.mockito.ArgumentMatchers.anyString());
 		}
 	}
 
@@ -173,7 +215,7 @@ class JDWPToolsSetBreakpointTest {
 		void shouldTreatBlankConditionAsNoCondition() throws Exception {
 			wireEagerSet("com.example.Foo", 10);
 
-			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", "   ", null, null);
+			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", "   ", null, null, null);
 
 			assertThat(result).doesNotContain("condition:");
 		}
@@ -183,7 +225,7 @@ class JDWPToolsSetBreakpointTest {
 		void shouldIncludeConditionInResponseWhenProvided() throws Exception {
 			wireEagerSet("com.example.Foo", 10);
 
-			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", "i > 0", null, null);
+			final String result = tools.jdwp_set_breakpoint("com.example.Foo", 10, "all", "i > 0", null, null, null);
 
 			assertThat(result).contains("condition: i > 0");
 		}

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsSetExceptionBreakpointTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsSetExceptionBreakpointTest.java
@@ -60,11 +60,11 @@ class JDWPToolsSetExceptionBreakpointTest {
 	void shouldDefaultCaughtAndUncaughtToTrue() throws Exception {
 		final ReferenceType refType = mock(ReferenceType.class);
 		final ExceptionRequest req = mock(ExceptionRequest.class);
-		when(jdiService.findOrForceLoadClass("java.lang.RuntimeException")).thenReturn(refType);
+		when(jdiService.findLoadedClass("java.lang.RuntimeException")).thenReturn(refType);
 		when(erm.createExceptionRequest(refType, true, true)).thenReturn(req);
 
 		final String result = tools.jdwp_set_exception_breakpoint(
-			"java.lang.RuntimeException", null, null, null, null);
+			"java.lang.RuntimeException", null, null, null, null, null);
 
 		assertThat(result).contains("Caught: true").contains("Uncaught: true").contains("Mode: suspend");
 		verify(erm).createExceptionRequest(refType, true, true);
@@ -74,11 +74,11 @@ class JDWPToolsSetExceptionBreakpointTest {
 	@DisplayName("deferred path — registers a ClassPrepareRequest when the exception class is unloaded")
 	void shouldDeferWhenExceptionClassIsUnloaded() throws Exception {
 		final ClassPrepareRequest cpr = mock(ClassPrepareRequest.class);
-		when(jdiService.findOrForceLoadClass("com.example.MyException")).thenReturn(null);
+		when(jdiService.findLoadedClass("com.example.MyException")).thenReturn(null);
 		when(erm.createClassPrepareRequest()).thenReturn(cpr);
 
 		final String result = tools.jdwp_set_exception_breakpoint(
-			"com.example.MyException", null, null, null, null);
+			"com.example.MyException", null, null, null, null, null);
 
 		assertThat(result).startsWith("Exception breakpoint deferred");
 		assertThat(result).contains("com.example.MyException");
@@ -90,7 +90,7 @@ class JDWPToolsSetExceptionBreakpointTest {
 	@DisplayName("rejects an unknown triggerBreakpointId without touching the VM")
 	void shouldRejectUnknownTrigger() throws Exception {
 		final String result = tools.jdwp_set_exception_breakpoint(
-			"java.lang.RuntimeException", null, null, 999, null);
+			"java.lang.RuntimeException", null, null, 999, null, null);
 
 		assertThat(result).startsWith("Error:").contains("Trigger breakpoint #999");
 	}
@@ -100,13 +100,13 @@ class JDWPToolsSetExceptionBreakpointTest {
 	void shouldAcceptKnownTriggerAndEmbedChainSuffix() throws Exception {
 		final ReferenceType refType = mock(ReferenceType.class);
 		final ExceptionRequest req = mock(ExceptionRequest.class);
-		when(jdiService.findOrForceLoadClass("java.lang.RuntimeException")).thenReturn(refType);
+		when(jdiService.findLoadedClass("java.lang.RuntimeException")).thenReturn(refType);
 		when(erm.createExceptionRequest(refType, true, true)).thenReturn(req);
 
 		final int triggerId = tracker.registerBreakpoint(mock(BreakpointRequest.class));
 
 		final String result = tools.jdwp_set_exception_breakpoint(
-			"java.lang.RuntimeException", null, null, triggerId, true);
+			"java.lang.RuntimeException", null, null, triggerId, true, null);
 
 		assertThat(result).contains("Chain: trigger=#" + triggerId).contains("one-shot");
 	}

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsSetExceptionLogpointTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/JDWPToolsSetExceptionLogpointTest.java
@@ -54,7 +54,7 @@ class JDWPToolsSetExceptionLogpointTest {
 	@DisplayName("rejects a null expression with a hard error and never touches the VM")
 	void shouldRejectNullExpression() throws Exception {
 		final String result = tools.jdwp_set_exception_logpoint(
-			"java.lang.RuntimeException", null, null, null, null, null, null);
+			"java.lang.RuntimeException", null, null, null, null, null, null, null);
 
 		assertThat(result).startsWith("Error:").contains("expression is required");
 		verify(jdiService, never()).getVM();
@@ -64,7 +64,7 @@ class JDWPToolsSetExceptionLogpointTest {
 	@DisplayName("rejects a blank expression with a hard error and never touches the VM")
 	void shouldRejectBlankExpression() throws Exception {
 		final String result = tools.jdwp_set_exception_logpoint(
-			"java.lang.RuntimeException", "   ", null, null, null, null, null);
+			"java.lang.RuntimeException", "   ", null, null, null, null, null, null);
 
 		assertThat(result).startsWith("Error:").contains("expression is required");
 		verify(jdiService, never()).getVM();
@@ -75,11 +75,11 @@ class JDWPToolsSetExceptionLogpointTest {
 	void shouldRenderLogOnlyModeAndExpression() throws Exception {
 		final ReferenceType refType = mock(ReferenceType.class);
 		final ExceptionRequest req = mock(ExceptionRequest.class);
-		when(jdiService.findOrForceLoadClass("java.lang.RuntimeException")).thenReturn(refType);
+		when(jdiService.findLoadedClass("java.lang.RuntimeException")).thenReturn(refType);
 		when(erm.createExceptionRequest(refType, true, true)).thenReturn(req);
 
 		final String result = tools.jdwp_set_exception_logpoint(
-			"java.lang.RuntimeException", "$exception.getMessage()", null, null, null, null, null);
+			"java.lang.RuntimeException", "$exception.getMessage()", null, null, null, null, null, null);
 
 		assertThat(result).contains("Mode: log-only");
 		assertThat(result).contains("Expression: $exception.getMessage()");
@@ -90,12 +90,12 @@ class JDWPToolsSetExceptionLogpointTest {
 	void shouldPersistCondition() throws Exception {
 		final ReferenceType refType = mock(ReferenceType.class);
 		final ExceptionRequest req = mock(ExceptionRequest.class);
-		when(jdiService.findOrForceLoadClass("java.lang.RuntimeException")).thenReturn(refType);
+		when(jdiService.findLoadedClass("java.lang.RuntimeException")).thenReturn(refType);
 		when(erm.createExceptionRequest(refType, true, true)).thenReturn(req);
 
 		final String result = tools.jdwp_set_exception_logpoint(
 			"java.lang.RuntimeException", "$exception.getMessage()",
-			"$exception.getMessage() != null", null, null, null, null);
+			"$exception.getMessage() != null", null, null, null, null, null);
 
 		assertThat(result).contains("Condition: $exception.getMessage() != null");
 		// And the metadata is queryable by the listener path via the synthetic ID.
@@ -108,11 +108,11 @@ class JDWPToolsSetExceptionLogpointTest {
 	void shouldTreatBlankConditionAsNoCondition() throws Exception {
 		final ReferenceType refType = mock(ReferenceType.class);
 		final ExceptionRequest req = mock(ExceptionRequest.class);
-		when(jdiService.findOrForceLoadClass("java.lang.RuntimeException")).thenReturn(refType);
+		when(jdiService.findLoadedClass("java.lang.RuntimeException")).thenReturn(refType);
 		when(erm.createExceptionRequest(refType, true, true)).thenReturn(req);
 
 		final String result = tools.jdwp_set_exception_logpoint(
-			"java.lang.RuntimeException", "$exception", "   ", null, null, null, null);
+			"java.lang.RuntimeException", "$exception", "   ", null, null, null, null, null);
 
 		assertThat(result).doesNotContain("Condition:");
 		final Integer id = tracker.getAllExceptionBreakpoints().keySet().stream().findFirst().orElseThrow();
@@ -124,11 +124,11 @@ class JDWPToolsSetExceptionLogpointTest {
 	void shouldDefaultCaughtAndUncaughtToTrue() throws Exception {
 		final ReferenceType refType = mock(ReferenceType.class);
 		final ExceptionRequest req = mock(ExceptionRequest.class);
-		when(jdiService.findOrForceLoadClass("java.lang.RuntimeException")).thenReturn(refType);
+		when(jdiService.findLoadedClass("java.lang.RuntimeException")).thenReturn(refType);
 		when(erm.createExceptionRequest(refType, true, true)).thenReturn(req);
 
 		final String result = tools.jdwp_set_exception_logpoint(
-			"java.lang.RuntimeException", "$exception", null, null, null, null, null);
+			"java.lang.RuntimeException", "$exception", null, null, null, null, null, null);
 
 		assertThat(result).contains("Caught: true").contains("Uncaught: true");
 		verify(erm).createExceptionRequest(refType, true, true);
@@ -138,11 +138,11 @@ class JDWPToolsSetExceptionLogpointTest {
 	@DisplayName("deferred path — registers a ClassPrepareRequest when the exception class is unloaded")
 	void shouldDeferWhenExceptionClassIsUnloaded() throws Exception {
 		final ClassPrepareRequest cpr = mock(ClassPrepareRequest.class);
-		when(jdiService.findOrForceLoadClass("com.example.MyException")).thenReturn(null);
+		when(jdiService.findLoadedClass("com.example.MyException")).thenReturn(null);
 		when(erm.createClassPrepareRequest()).thenReturn(cpr);
 
 		final String result = tools.jdwp_set_exception_logpoint(
-			"com.example.MyException", "$exception", "$exception != null", null, null, null, null);
+			"com.example.MyException", "$exception", "$exception != null", null, null, null, null, null);
 
 		assertThat(result).startsWith("Exception breakpoint deferred");
 		assertThat(result).contains("Mode: log-only");
@@ -159,7 +159,7 @@ class JDWPToolsSetExceptionLogpointTest {
 	@DisplayName("rejects an unknown triggerBreakpointId without touching the VM")
 	void shouldRejectUnknownTrigger() throws Exception {
 		final String result = tools.jdwp_set_exception_logpoint(
-			"java.lang.RuntimeException", "$exception", null, null, null, 999, null);
+			"java.lang.RuntimeException", "$exception", null, null, null, 999, null, null);
 
 		assertThat(result).startsWith("Error:").contains("Trigger breakpoint #999");
 		verify(jdiService, never()).getVM();
@@ -170,13 +170,13 @@ class JDWPToolsSetExceptionLogpointTest {
 	void shouldAcceptKnownTriggerAndEmbedChainSuffix() throws Exception {
 		final ReferenceType refType = mock(ReferenceType.class);
 		final ExceptionRequest req = mock(ExceptionRequest.class);
-		when(jdiService.findOrForceLoadClass("java.lang.RuntimeException")).thenReturn(refType);
+		when(jdiService.findLoadedClass("java.lang.RuntimeException")).thenReturn(refType);
 		when(erm.createExceptionRequest(refType, true, true)).thenReturn(req);
 
 		final int triggerId = tracker.registerBreakpoint(mock(BreakpointRequest.class));
 
 		final String result = tools.jdwp_set_exception_logpoint(
-			"java.lang.RuntimeException", "$exception", null, null, null, triggerId, true);
+			"java.lang.RuntimeException", "$exception", null, null, null, triggerId, true, null);
 
 		assertThat(result).contains("Chain: trigger=#" + triggerId).contains("one-shot");
 	}


### PR DESCRIPTION
Closes #3.

## Summary

- Adds `JDIConnectionService#findLoadedClass(String)` — passive class lookup (`classesByName` + `allClasses()` scan, no `Class.forName` invoke).
- Adds `Boolean forceLoad` opt-in parameter to the six set-breakpoint MCP tools: `jdwp_set_breakpoint`, `jdwp_set_logpoint`, `jdwp_set_exception_breakpoint`, `jdwp_set_exception_logpoint`, `jdwp_set_field_breakpoint`, `jdwp_set_field_logpoint`. Default `false` = passive (defer via `ClassPrepareRequest`); `true` = force-load and accept the side effects.
- `BreakpointTracker#tryPromotePending` now uses `findLoadedClass` exclusively. The unused `preferredThread` parameter is dropped.
- Tool descriptions and Javadoc updated to reflect the passive-by-default contract.

## Why

Before this change, every set-breakpoint tool called `Class.forName(name)` inside the target VM as a fast path when the class wasn't yet visible. That changes target-application behaviour a debugger should only observe:

- Triggers the class's `<clinit>` earlier than the application would have on its own.
- Cascade-loads dependencies referenced from `<clinit>`.
- Masks lazy-init / classloader-leak diagnostics — exactly the kind of question users use a debugger to answer.
- Fires user breakpoints inside the forced load (the `EvaluationGuard` exists in large part to muffle this).
- Is the worker-parked-inside-`invokeMethod` half of the deadlock pattern PR #2 fixed.

Standard debuggers (IntelliJ, Eclipse, jdb) register a `ClassPrepareRequest` and wait. This change matches that behaviour by default; force-load remains available as an opt-in for legitimate cases (typically `java.*` / `jdk.*` exception classes whose `ClassPrepareEvent` is never delivered).

## Bonus payoff

Removing the automatic `Class.forName` call from the set-breakpoint hot path eliminates the root cause of the deadlock class that PR #2 fixed via monitor release. Force-load remains available via `findOrForceLoadClass` for the rare call sites that need it (expression / watcher evaluation, explicit `forceLoad=true`).

## Tests

- 879 tests green (up from 876).
- New regression guards:
  - `JDWPToolsSetBreakpointTest::shouldNeverForceLoadOnDefaultRegistration` — default path never invokes `findOrForceLoadClass`.
  - `JDWPToolsSetBreakpointTest::shouldRouteToForceLoadWhenForceLoadTrue` — opt-in path routes to the force-load primitive.
  - `BreakpointTrackerExceptionAndMetadataTest::shouldNeverCallFindOrForceLoadClassFromSafetyNet` — the safety-net promoter never force-loads across line / exception / field arms.
- Existing tests that mocked `findOrForceLoadClass` for the default code path were migrated to mock `findLoadedClass`; the deadlock-probe tests (`BreakpointTrackerPromotionDeadlockTest`) still demonstrate the monitor-release property using the passive lookup as the slow stub.

## Test plan

- [x] `./mvnw -pl jdwp-mcp-server test` — green.
- [ ] Manual smoke: `jdwp_set_breakpoint` on an unloaded class defers without running `<clinit>`; `forceLoad=true` binds immediately and runs `<clinit>` once.
- [ ] Manual smoke: `jdwp_set_exception_breakpoint("java.sql.SQLException", forceLoad=true)` binds against the bootstrap class on first use.