### PR TITLE
fix: emit eval wrapper into target's package when this is non-public (#7)

### DIFF
--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JdiEventListener.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JdiEventListener.java
@@ -793,7 +793,7 @@ public class JdiEventListener {
      * watchpoint hit. {@code $oldValue} (always — null for the first write to an uninitialised
      * reference field), {@code $newValue} (always for {@link ModificationWatchpointEvent}, otherwise
      * absent), and {@code $object} (null for static-field events) are bound. Null values are bound
-     * as the typed-null literal by {@link JdiExpressionEvaluator#inferDeclaredType(Value)} ({@code
+     * as the typed-null literal by {@code JdiExpressionEvaluator#inferDeclaredType} ({@code
      * java.lang.Object}), so string-concatenation expressions like {@code "$oldValue + \" -> \" +
      * $newValue"} render the literal {@code "null"} instead of failing at compile time.
      * <p>

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
@@ -22,8 +22,10 @@ import java.util.stream.Collectors;
  * 2. Auto-rewrite bare field identifiers (`field` → `_this.field`) via
  * {@link #rewriteThisFieldReferences} when safe; explicit `this`/`this.field` is handled
  * separately by {@link #rewriteThisKeyword}.
- * 3. Cache lookup keyed on `signature + "###" + expression`; on miss, generate a wrapper class
- * with a UUID-suffixed name, compile via {@link InMemoryJavaCompiler}, and cache the bytecode.
+ * 3. Cache lookup keyed on `wrapperPackage + "###" + signature + "###" + expression` (the package
+ * is part of the key because a define-time fallback may recompile the same expression into a
+ * different package); on miss, generate a wrapper class with a UUID-suffixed name, compile via
+ * {@link InMemoryJavaCompiler}, and cache the bytecode.
  * 4. Inject the bytecode into the target VM and execute via {@link RemoteCodeExecutor}.
  * <p>
  * Cache eviction: when {@link #compilationCache} reaches {@link #MAX_CACHE_SIZE} entries it is
@@ -751,11 +753,13 @@ public class JdiExpressionEvaluator {
      * Evaluates `expression` in the context of `frame` plus any caller-supplied synthetic bindings,
      * and returns the result as a JDI {@link Value}. Side effect: populates {@link #compilationCache}.
      *
-     * <p>The auto-rewrite of bare {@code this.field} references runs when EITHER {@code this}'s
-     * declared type is public OR the wrapper is emitted into {@code this}'s own package (see
-     * {@link #resolveWrapperPackage}). In the latter case package-private and protected fields
-     * also become candidates — subject to {@link #isFieldAccessibleFromWrapper}'s per-field
-     * accessibility check.
+     * <p>The auto-rewrite of bare field identifiers ({@code field} → {@code _this.field}, via
+     * {@link #rewriteThisFieldReferences}) runs when EITHER {@code this}'s declared type is public
+     * OR the wrapper is emitted into {@code this}'s own package (see {@link #resolveWrapperPackage}).
+     * In the latter case package-private and protected fields also become candidates — subject to
+     * {@link #isFieldAccessibleFromWrapper}'s per-field accessibility check. (Explicit {@code this}
+     * and {@code this.field} are handled separately and unconditionally by
+     * {@link #rewriteThisKeyword}.)
      *
      * <p>Synthetic bindings (e.g. {@code "$exception" -> ObjectReference}) appear in the wrapper's
      * parameter list after the real locals and can be referenced by name in the expression. This is
@@ -813,6 +817,12 @@ public class JdiExpressionEvaluator {
         } catch (Exception e) {
             log.warn("[Evaluator] Expression evaluation failed after {}ms: {}",
                 System.currentTimeMillis() - startTime, e.getMessage());
+            // Already a pipeline exception (incl. JdiClassDefinitionException) — propagate it
+            // unchanged so the define-vs-invoke subtype and its original message survive rather
+            // than being flattened into a generic "Expression evaluation failed" wrapper.
+            if (e instanceof JdiEvaluationException jdi) {
+                throw jdi;
+            }
             // Un-wrap runtime exception from cache computation
             if (e instanceof RuntimeException && e.getCause() instanceof JdiEvaluationException jdiEx) {
                 throw jdiEx;

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
@@ -632,7 +632,8 @@ public class JdiExpressionEvaluator {
         // SecurityException far from the decision site.
         if (pkg.isEmpty() || pkg.startsWith("java.") || pkg.equals("java")
             || pkg.startsWith("javax.") || pkg.equals("javax")
-            || pkg.startsWith("sun.") || pkg.startsWith("jdk.")) {
+            || pkg.startsWith("sun.") || pkg.equals("sun")
+            || pkg.startsWith("jdk.") || pkg.equals("jdk")) {
             return DEFAULT_EVALUATION_PACKAGE;
         }
         return pkg;

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
@@ -18,7 +18,9 @@ import java.util.stream.Collectors;
  * <p>
  * Pipeline (per call to {@link #evaluate}):
  * 1. Build evaluation context from the frame (locals + `this`).
- * 2. Auto-rewrite bare `this.field` references via {@link #rewriteThisFieldReferences} when safe.
+ * 2. Auto-rewrite bare field identifiers (`field` → `_this.field`) via
+ * {@link #rewriteThisFieldReferences} when safe; explicit `this`/`this.field` is handled
+ * separately by {@link #rewriteThisKeyword}.
  * 3. Cache lookup keyed on `signature + "###" + expression`; on miss, generate a wrapper class
  * with a UUID-suffixed name, compile via {@link InMemoryJavaCompiler}, and cache the bytecode.
  * 4. Inject the bytecode into the target VM and execute via {@link RemoteCodeExecutor}.
@@ -414,9 +416,14 @@ public class JdiExpressionEvaluator {
      *   <li><b>Non-public types in {@code wrapperPackage}</b> — exposed by their actual binary name
      *       (with nested-class {@code $} → {@code .} so the compiler accepts the source form). The
      *       wrapper lives in the same package, so package-private types and members are reachable.</li>
-     *   <li><b>Non-public types in other packages</b> — walk up the superclass chain until a type
-     *       the wrapper CAN reference is found (public, or sharing {@code wrapperPackage}), falling
-     *       back to {@code java.lang.Object}.</li>
+     *   <li><b>Non-public class types in other packages</b> — walk up the superclass chain until a
+     *       type the wrapper CAN reference is found (public, or sharing {@code wrapperPackage}),
+     *       falling back to {@code java.lang.Object}.</li>
+     *   <li><b>Non-public interface types in other packages</b> — a local declared as a non-public
+     *       interface (e.g. a package-private interface) reaches here via {@link #resolveLocalVarType}.
+     *       Walk the {@code superinterfaces()} graph for a reachable interface, falling back to
+     *       {@code java.lang.Object}. Without this the raw interface name would be emitted and the
+     *       wrapper would fail to compile.</li>
      * </ul>
      *
      * @param wrapperPackage the package the wrapper class lives in; types in this package are
@@ -458,20 +465,51 @@ public class JdiExpressionEvaluator {
                 return "java.lang.Object";
             }
 
+            // A non-public interface (typically a package-private interface used as a local's
+            // declared type) cannot be named from the wrapper. Walk its superinterface graph for
+            // one that can, else fall back to Object — the value is always assignable to it.
+            if (type instanceof InterfaceType interfaceType) {
+                final InterfaceType reachable = findReachableInterface(interfaceType, wrapperPackage, new HashSet<>());
+                return reachable != null ? toSourceTypeName(reachable.name()) : "java.lang.Object";
+            }
+
             return toSourceTypeName(typeName);
         }
     }
 
     /**
-     * Whether {@code type} can be referenced by name from a wrapper class living in
-     * {@code wrapperPackage}. True if the type is public, or if it lives in the same package and
-     * is neither {@code private} nor a local/anonymous class. Private nested classes are
+     * Depth-first search of {@code type}'s superinterface graph for an interface the wrapper class
+     * can reference (public, or non-public but sharing {@code wrapperPackage}). Returns {@code null}
+     * when none is reachable, so the caller falls back to {@code java.lang.Object}. The
+     * {@code visited} set guards against the diamond inheritance interfaces routinely exhibit.
+     */
+    @Nullable
+    private static InterfaceType findReachableInterface(InterfaceType type, String wrapperPackage, Set<String> visited) {
+        if (!visited.add(type.name())) {
+            return null;
+        }
+        if (isReachableFromWrapper(type, wrapperPackage)) {
+            return type;
+        }
+        for (InterfaceType parent : type.superinterfaces()) {
+            final InterfaceType found = findReachableInterface(parent, wrapperPackage, visited);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Whether {@code type} (a class or interface) can be referenced by name from a wrapper class
+     * living in {@code wrapperPackage}. True if the type is public, or if it lives in the same
+     * package and is neither {@code private} nor a local/anonymous class. Private nested types are
      * accessible only from inside their enclosing class — even another top-level class in the
      * same package can't reach them — so they walk to a public supertype like any other
      * unreachable case. Local/anonymous classes ({@code $<digit>} in the binary name) are
      * unaddressable from source anywhere.
      */
-    private static boolean isReachableFromWrapper(ClassType type, String wrapperPackage) {
+    private static boolean isReachableFromWrapper(ReferenceType type, String wrapperPackage) {
         if (type.isPublic()) {
             return true;
         }

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
@@ -3,6 +3,7 @@ package one.edee.mcp.jdwp.evaluation;
 import com.sun.jdi.*;
 import one.edee.mcp.jdwp.EvaluationGuard;
 import one.edee.mcp.jdwp.JDIConnectionService;
+import one.edee.mcp.jdwp.evaluation.exceptions.JdiClassDefinitionException;
 import one.edee.mcp.jdwp.evaluation.exceptions.JdiEvaluationException;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -480,8 +481,10 @@ public class JdiExpressionEvaluator {
     /**
      * Depth-first search of {@code type}'s superinterface graph for an interface the wrapper class
      * can reference (public, or non-public but sharing {@code wrapperPackage}). Returns {@code null}
-     * when none is reachable, so the caller falls back to {@code java.lang.Object}. The
-     * {@code visited} set guards against the diamond inheritance interfaces routinely exhibit.
+     * when none is reachable, so the caller falls back to {@code java.lang.Object}. Interface
+     * inheritance is acyclic, so the walk terminates regardless; the {@code visited} set just
+     * avoids re-expanding a shared parent in the diamonds interfaces routinely exhibit (and stays
+     * safe against pathological/cyclic input).
      */
     @Nullable
     private static InterfaceType findReachableInterface(InterfaceType type, String wrapperPackage, Set<String> visited) {
@@ -595,6 +598,16 @@ public class JdiExpressionEvaluator {
      * </ul>
      * Local and anonymous classes ({@code $<digit>}) must be filtered upstream; this method
      * does not reject them because the same conversion is occasionally useful for diagnostics.
+     *
+     * <p><b>Known limitation:</b> a {@code $} embedded between identifier characters is treated as a
+     * nesting separator even for a <em>top-level</em> type whose simple name genuinely contains
+     * {@code $} (e.g. {@code class Foo$Bar {}}), so {@code Foo$Bar} is rendered as {@code Foo.Bar}
+     * and the wrapper fails to compile for that type. A binary name alone cannot distinguish the two
+     * cases — {@code Outer$Inner} (a member type) and a top-level {@code Foo$Bar} are identical
+     * strings — and disambiguating would require a per-type VM round-trip (or compile-then-fallback)
+     * disproportionate to the risk: JLS §3.8 reserves {@code $} for "mechanically generated source
+     * code", so such top-level names do not occur in normal application code. Accepted as a
+     * limitation rather than guarded.
      */
     private static String toSourceTypeName(String binaryName) {
         if (binaryName.indexOf('$') < 0 || binaryName.contains("$$")) {
@@ -781,104 +794,22 @@ public class JdiExpressionEvaluator {
             final ObjectReference thisObject = frame.thisObject();
             final String wrapperPackage = resolveWrapperPackage(thisObject);
 
-            // 1. Analyze the frame to build the evaluation context
-            final EvaluationContext context = buildContext(frame, extraBindings, wrapperPackage);
-
-            // Auto-rewrite bare references to fields of `this` so users can write
-            // `sessions.containsKey(session)` instead of `_this.sessions.containsKey(session)`.
-            // Each candidate field is filtered for accessibility from the wrapper class:
-            //  - When the wrapper lives in the default isolated package, only public fields on a
-            //    public declaring type are reachable.
-            //  - When the wrapper lives in `this`'s own package, public/protected/package-private
-            //    fields are reachable PROVIDED the field's declaring type ALSO lives in that
-            //    package. A protected field inherited from a class in some other package is not
-            //    accessible from a non-subclass even when `this`'s runtime type is in the wrapper
-            //    package — so we'd produce a misleading "not visible" error if we rewrote it.
-            //  - Private fields are never rewritten.
-            if (thisObject != null && thisObject.referenceType() instanceof ClassType thisClass) {
-                final boolean sharingPackage = !wrapperPackage.equals(DEFAULT_EVALUATION_PACKAGE)
-                    && wrapperPackage.equals(packageOf(thisClass.name()));
-                if (thisClass.isPublic() || sharingPackage) {
-                    final Set<String> shadowingLocals = context.getVariables().stream()
-                        .map(v -> v.name)
-                        .collect(Collectors.toSet());
-                    final Set<String> rewritableFieldNames = thisClass.allFields().stream()
-                        .filter(f -> isFieldAccessibleFromWrapper(f, wrapperPackage, sharingPackage))
-                        .map(Field::name)
-                        .collect(Collectors.toSet());
-                    expression = rewriteThisFieldReferences(expression, rewritableFieldNames, shadowingLocals);
+            try {
+                return evaluateInPackage(frame, expression, extraBindings, wrapperPackage, startTime);
+            } catch (JdiClassDefinitionException defineFailure) {
+                // The wrapper could not be DEFINED into the chosen package — a sealed package, module
+                // strong-encapsulation, or a restrictive custom classloader can reject defineClass for
+                // an application package while still accepting the isolated default package. The user
+                // expression never ran (the failure is in the define phase, before invoke), so it is
+                // safe to retry once in the default package. This preserves the pre-target-package
+                // behaviour for public-only expressions instead of regressing them to a hard failure.
+                if (wrapperPackage.equals(DEFAULT_EVALUATION_PACKAGE)) {
+                    throw defineFailure;
                 }
+                log.warn("[Evaluator] Defining wrapper into package '{}' failed ({}); retrying in default package '{}'",
+                    wrapperPackage, defineFailure.getMessage(), DEFAULT_EVALUATION_PACKAGE);
+                return evaluateInPackage(frame, expression, extraBindings, DEFAULT_EVALUATION_PACKAGE, startTime);
             }
-
-            // 2. Use cache key based on context + expression (excludes UUID for cache hits)
-            final String cacheKey = context.getSignature() + "###" + expression;
-
-            // Full-flush eviction is deliberate: LRU bookkeeping isn't worth it for a cache whose
-            // miss cost (compile + cache) is already orders of magnitude larger than just rebuilding
-            // the few entries that get hot again.
-            if (compilationCache.size() >= MAX_CACHE_SIZE) {
-                log.info("[Evaluator] Compilation cache reached {} entries, clearing", compilationCache.size());
-                compilationCache.clear();
-            }
-
-            final CachedCompilation cached = compilationCache.get(cacheKey);
-
-            final String className;
-            byte[] bytecode;
-
-            if (cached != null) {
-                // Cache hit — reuse previously compiled class name and bytecode
-                className = cached.className;
-                bytecode = cached.bytecode;
-            } else {
-                // Cache miss — generate unique class name, compile, and cache
-                final String uniqueId = UUID.randomUUID().toString().replace("-", "");
-                className = wrapperPackage + '.' + EVALUATION_CLASS_PREFIX + uniqueId;
-
-                final String sourceCode = generateSourceCode(className, context, expression);
-
-                final Map<String, byte[]> compiledCode = compiler.compile(className, sourceCode);
-
-                bytecode = compiledCode.get(className);
-                if (bytecode == null) {
-                    // Some compilers key by binary name with slashes, simple name, or with leading slashes —
-                    // fall back to a suffix match on the simple class name.
-                    final String simpleName = className.substring(className.lastIndexOf('.') + 1);
-                    for (Map.Entry<String, byte[]> entry : compiledCode.entrySet()) {
-                        final String key = entry.getKey();
-                        String keyTail = key.substring(key.lastIndexOf('/') + 1).replace(".class", "");
-                        keyTail = keyTail.substring(keyTail.lastIndexOf('.') + 1);
-                        if (keyTail.equals(simpleName)) {
-                            bytecode = entry.getValue();
-                            log.debug("[Evaluator] Bytecode found via fallback key '{}' for class '{}'", key, className);
-                            break;
-                        }
-                    }
-                }
-                if (bytecode == null) {
-                    throw new JdiEvaluationException("Could not find compiled bytecode for class " + className
-                        + " (available keys: " + compiledCode.keySet() + ')');
-                }
-
-                compilationCache.put(cacheKey, new CachedCompilation(className, bytecode));
-            }
-
-            // 3. Find a suitable class loader in the target VM
-            final ClassLoaderReference classLoader = findClassLoader(frame);
-
-            // 4. Execute the code remotely
-            final Value value = RemoteCodeExecutor.execute(
-                frame.virtualMachine(),
-                frame.thread(),
-                classLoader,
-                className,
-                bytecode,
-                EVALUATION_METHOD_NAME,
-                context.getValues()
-            );
-            log.info("[Evaluator] Expression evaluated in {}ms (cache {})",
-                System.currentTimeMillis() - startTime, cached != null ? "hit" : "miss");
-            return value;
         } catch (Exception e) {
             log.warn("[Evaluator] Expression evaluation failed after {}ms: {}",
                 System.currentTimeMillis() - startTime, e.getMessage());
@@ -890,6 +821,125 @@ public class JdiExpressionEvaluator {
         } finally {
             evaluationGuard.exit(guardedThreadId);
         }
+    }
+
+    /**
+     * Builds the evaluation context, compiles (or reuses a cached) wrapper class living in
+     * {@code wrapperPackage}, defines it into the target VM, and invokes it. Factored out of
+     * {@link #evaluate} so that method can retry in {@link #DEFAULT_EVALUATION_PACKAGE} when a
+     * non-default package is rejected at define time — see {@link JdiClassDefinitionException}.
+     * <p>
+     * The {@code this.field} rewrite is performed here (not in the caller) because which fields are
+     * reachable from the wrapper depends on {@code wrapperPackage}; a retry in a different package
+     * must redo it from the original expression. {@code expression} is the local parameter, so the
+     * reassignment never leaks back to {@link #evaluate}.
+     */
+    private @Nullable Value evaluateInPackage(StackFrame frame, String expression,
+                                              Map<String, Value> extraBindings, String wrapperPackage,
+                                              long startTime)
+        throws JdiEvaluationException, AbsentInformationException {
+        // 1. Analyze the frame to build the evaluation context
+        final EvaluationContext context = buildContext(frame, extraBindings, wrapperPackage);
+
+        // Auto-rewrite bare references to fields of `this` so users can write
+        // `sessions.containsKey(session)` instead of `_this.sessions.containsKey(session)`.
+        // Each candidate field is filtered for accessibility from the wrapper class:
+        //  - When the wrapper lives in the default isolated package, only public fields on a
+        //    public declaring type are reachable.
+        //  - When the wrapper lives in `this`'s own package, public/protected/package-private
+        //    fields are reachable PROVIDED the field's declaring type ALSO lives in that
+        //    package. A protected field inherited from a class in some other package is not
+        //    accessible from a non-subclass even when `this`'s runtime type is in the wrapper
+        //    package — so we'd produce a misleading "not visible" error if we rewrote it.
+        //  - Private fields are never rewritten.
+        final ObjectReference thisObject = frame.thisObject();
+        if (thisObject != null && thisObject.referenceType() instanceof ClassType thisClass) {
+            final boolean sharingPackage = !wrapperPackage.equals(DEFAULT_EVALUATION_PACKAGE)
+                && wrapperPackage.equals(packageOf(thisClass.name()));
+            if (thisClass.isPublic() || sharingPackage) {
+                final Set<String> shadowingLocals = context.getVariables().stream()
+                    .map(v -> v.name)
+                    .collect(Collectors.toSet());
+                final Set<String> rewritableFieldNames = thisClass.allFields().stream()
+                    .filter(f -> isFieldAccessibleFromWrapper(f, wrapperPackage, sharingPackage))
+                    .map(Field::name)
+                    .collect(Collectors.toSet());
+                expression = rewriteThisFieldReferences(expression, rewritableFieldNames, shadowingLocals);
+            }
+        }
+
+        // 2. Cache key includes the wrapper package: the same (signature, expression) may be
+        //    compiled into two different packages (e.g. after a define-time fallback), and the
+        //    cached className + bytecode are package-specific.
+        final String cacheKey = wrapperPackage + "###" + context.getSignature() + "###" + expression;
+
+        // Full-flush eviction is deliberate: LRU bookkeeping isn't worth it for a cache whose
+        // miss cost (compile + cache) is already orders of magnitude larger than just rebuilding
+        // the few entries that get hot again.
+        if (compilationCache.size() >= MAX_CACHE_SIZE) {
+            log.info("[Evaluator] Compilation cache reached {} entries, clearing", compilationCache.size());
+            compilationCache.clear();
+        }
+
+        final CachedCompilation cached = compilationCache.get(cacheKey);
+
+        final String className;
+        byte[] bytecode;
+
+        if (cached != null) {
+            // Cache hit — reuse previously compiled class name and bytecode
+            className = cached.className;
+            bytecode = cached.bytecode;
+        } else {
+            // Cache miss — generate unique class name, compile, and cache
+            final String uniqueId = UUID.randomUUID().toString().replace("-", "");
+            className = wrapperPackage + '.' + EVALUATION_CLASS_PREFIX + uniqueId;
+
+            final String sourceCode = generateSourceCode(className, context, expression);
+
+            final Map<String, byte[]> compiledCode = compiler.compile(className, sourceCode);
+
+            bytecode = compiledCode.get(className);
+            if (bytecode == null) {
+                // Some compilers key by binary name with slashes, simple name, or with leading slashes —
+                // fall back to a suffix match on the simple class name.
+                final String simpleName = className.substring(className.lastIndexOf('.') + 1);
+                for (Map.Entry<String, byte[]> entry : compiledCode.entrySet()) {
+                    final String key = entry.getKey();
+                    String keyTail = key.substring(key.lastIndexOf('/') + 1).replace(".class", "");
+                    keyTail = keyTail.substring(keyTail.lastIndexOf('.') + 1);
+                    if (keyTail.equals(simpleName)) {
+                        bytecode = entry.getValue();
+                        log.debug("[Evaluator] Bytecode found via fallback key '{}' for class '{}'", key, className);
+                        break;
+                    }
+                }
+            }
+            if (bytecode == null) {
+                throw new JdiEvaluationException("Could not find compiled bytecode for class " + className
+                    + " (available keys: " + compiledCode.keySet() + ')');
+            }
+
+            compilationCache.put(cacheKey, new CachedCompilation(className, bytecode));
+        }
+
+        // 3. Find a suitable class loader in the target VM
+        final ClassLoaderReference classLoader = findClassLoader(frame);
+
+        // 4. Execute the code remotely. A define-phase rejection surfaces as
+        //    JdiClassDefinitionException, which the caller may catch to retry in the default package.
+        final Value value = RemoteCodeExecutor.execute(
+            frame.virtualMachine(),
+            frame.thread(),
+            classLoader,
+            className,
+            bytecode,
+            EVALUATION_METHOD_NAME,
+            context.getValues()
+        );
+        log.info("[Evaluator] Expression evaluated in {}ms (cache {})",
+            System.currentTimeMillis() - startTime, cached != null ? "hit" : "miss");
+        return value;
     }
 
     /**

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
@@ -40,9 +40,12 @@ public class JdiExpressionEvaluator {
     private static final Logger log = LoggerFactory.getLogger(JdiExpressionEvaluator.class);
 
     /**
-     * Package name baked into every generated wrapper class — kept short and isolated from app code.
+     * Default package used for the generated wrapper class when {@code this} is public (or absent).
+     * Kept short and isolated from app code. Non-public {@code this} types may instead emit the
+     * wrapper into {@code this}'s own package so package-private fields and the type itself become
+     * reachable — see {@link #resolveWrapperPackage}.
      */
-    private static final String EVALUATION_PACKAGE = "mcp.jdi.evaluation";
+    private static final String DEFAULT_EVALUATION_PACKAGE = "mcp.jdi.evaluation";
     /**
      * Class name prefix; the actual name is `<prefix><UUID>` for collision-free reloads.
      */
@@ -290,8 +293,13 @@ public class JdiExpressionEvaluator {
      *                       order is preserved as wrapper-method parameter order — pass a
      *                       {@link java.util.LinkedHashMap} or {@code Map.of(...)} to keep the
      *                       order deterministic.
+     * @param wrapperPackage the package the wrapper class will live in. When this matches the
+     *                       package of a referenced type, that type's package-private members
+     *                       become accessible to the wrapper, so the type can be exposed by its
+     *                       actual (non-public) name instead of walking up to a public supertype.
      */
-    private static EvaluationContext buildContext(StackFrame frame, Map<String, Value> extraBindings)
+    private static EvaluationContext buildContext(StackFrame frame, Map<String, Value> extraBindings,
+                                                  String wrapperPackage)
         throws AbsentInformationException {
         final List<ContextVariable> variables = new ArrayList<>();
         final List<Value> values = new ArrayList<>();
@@ -299,7 +307,7 @@ public class JdiExpressionEvaluator {
         final ObjectReference thisObject = frame.thisObject();
         if (thisObject != null) {
             // Use declared type instead of runtime type to avoid issues with dynamic proxies (Guice, CGLIB, etc.)
-            final String declaredType = getDeclaredType(thisObject.referenceType());
+            final String declaredType = getDeclaredType(thisObject.referenceType(), wrapperPackage);
             variables.add(new ContextVariable("_this", declaredType));
             values.add(thisObject);
         }
@@ -310,7 +318,7 @@ public class JdiExpressionEvaluator {
             // inside it. The `isArgument()` allowance is defensive — a real argument named `this$N`
             // would be unusual but is technically valid bytecode.
             if (var.isArgument() || !var.name().startsWith("this$")) {
-                final String typeName = resolveLocalVarType(var);
+                final String typeName = resolveLocalVarType(var, wrapperPackage);
                 variables.add(new ContextVariable(var.name(), typeName));
                 values.add(frame.getValue(var));
             }
@@ -320,7 +328,7 @@ public class JdiExpressionEvaluator {
         // signature. Cache key (signature + expression) naturally varies on the bound type, so two
         // different exception subclasses thrown at the same site get distinct cached compilations.
         for (Map.Entry<String, Value> entry : extraBindings.entrySet()) {
-            variables.add(new ContextVariable(entry.getKey(), inferDeclaredType(entry.getValue())));
+            variables.add(new ContextVariable(entry.getKey(), inferDeclaredType(entry.getValue(), wrapperPackage)));
             values.add(entry.getValue());
         }
 
@@ -329,13 +337,13 @@ public class JdiExpressionEvaluator {
 
     /**
      * Resolves a wrapper-visible declared type for a JDI {@link Value}. Mirrors the public-supertype
-     * walk performed by {@link #getDeclaredType(ReferenceType)} so a non-public exception subclass
-     * still binds as a public ancestor (worst case {@code java.lang.Object}). Falls back to
-     * {@code java.lang.Object} for {@code null} and unrecognised value kinds.
+     * walk performed by {@link #getDeclaredType(ReferenceType, String)} so a non-public exception
+     * subclass still binds as a public ancestor (worst case {@code java.lang.Object}). Falls back
+     * to {@code java.lang.Object} for {@code null} and unrecognised value kinds.
      */
-    private static String inferDeclaredType(@Nullable Value value) {
+    private static String inferDeclaredType(@Nullable Value value, String wrapperPackage) {
         if (value instanceof ObjectReference objRef) {
-            return getDeclaredType(objRef.referenceType());
+            return getDeclaredType(objRef.referenceType(), wrapperPackage);
         }
         if (value instanceof PrimitiveValue primValue) {
             return primValue.type().name();
@@ -345,13 +353,14 @@ public class JdiExpressionEvaluator {
 
     /**
      * Resolves a local variable's declared type to one the wrapper class can reference.
-     * Falls back to a public supertype (or Object) for non-public types.
+     * Falls back to a public supertype (or Object) for non-public types that live outside the
+     * wrapper's package.
      */
-    private static String resolveLocalVarType(LocalVariable var) {
+    private static String resolveLocalVarType(LocalVariable var, String wrapperPackage) {
         try {
             final Type t = var.type();
             if (t instanceof ReferenceType refType) {
-                return getDeclaredType(refType);
+                return getDeclaredType(refType, wrapperPackage);
             }
             return t.name();
         } catch (ClassNotLoadedException e) {
@@ -366,10 +375,16 @@ public class JdiExpressionEvaluator {
      * is wrapped in `(Object)(...)` so any value type — including primitives via autoboxing —
      * can be returned. The bare `this` keyword in the expression is tokenizer-rewritten to `_this`
      * because the wrapper class doesn't have a `this` reference (it's a static method).
+     *
+     * <p>The package portion of {@code className} drives the wrapper's {@code package} declaration.
+     * When the caller routes a non-public {@code this} type into its own package via
+     * {@link #resolveWrapperPackage}, the wrapper compiles next to that type and can dereference
+     * its package-private members directly.
      */
     private static String generateSourceCode(String className, EvaluationContext context, String expression) {
-        final String packageName = EVALUATION_PACKAGE;
-        final String simpleClassName = className.substring(packageName.length() + 1);
+        final int lastDot = className.lastIndexOf('.');
+        final String packageName = lastDot < 0 ? "" : className.substring(0, lastDot);
+        final String simpleClassName = lastDot < 0 ? className : className.substring(lastDot + 1);
 
         final String methodParameters = context.getVariables().stream()
             .map(v -> v.type + ' ' + v.name)
@@ -380,8 +395,8 @@ public class JdiExpressionEvaluator {
         // literals are NOT rewritten — see {@link #rewriteThisKeyword(String)}.
         final String safeExpression = rewriteThisKeyword(expression);
 
-        return "package " + packageName + ";\n" +
-            '\n' +
+        final String packageDecl = packageName.isEmpty() ? "" : "package " + packageName + ";\n\n";
+        return packageDecl +
             "// Automatically generated class for JDI expression evaluation\n" +
             "public class " + simpleClassName + " {\n" +
             "    public static Object " + EVALUATION_METHOD_NAME + '(' + methodParameters + ") {\n" +
@@ -393,15 +408,22 @@ public class JdiExpressionEvaluator {
 
     /**
      * Get a name suitable to use in the generated wrapper class for the given runtime type.
-     * Handles two cases the wrapper compiler cannot otherwise express:
+     * Handles three cases the wrapper compiler cannot otherwise express:
      * <ul>
      *   <li><b>Dynamic proxies</b> (Guice, CGLIB, Mockito, Spring AOP) — unwrap to the real class.</li>
-     *   <li><b>Non-public types</b> (e.g., package-private test classes) — walk up the superclass
-     *       chain until a public type is found, falling back to {@code java.lang.Object}. The wrapper
-     *       class lives in {@code mcp.jdi.evaluation} and can only reference public types.</li>
+     *   <li><b>Non-public types in {@code wrapperPackage}</b> — exposed by their actual binary name
+     *       (with nested-class {@code $} → {@code .} so the compiler accepts the source form). The
+     *       wrapper lives in the same package, so package-private types and members are reachable.</li>
+     *   <li><b>Non-public types in other packages</b> — walk up the superclass chain until a type
+     *       the wrapper CAN reference is found (public, or sharing {@code wrapperPackage}), falling
+     *       back to {@code java.lang.Object}.</li>
      * </ul>
+     *
+     * @param wrapperPackage the package the wrapper class lives in; types in this package are
+     *                       reachable even when package-private. Pass {@link #DEFAULT_EVALUATION_PACKAGE}
+     *                       for the legacy "only public types reachable" behaviour.
      */
-    private static String getDeclaredType(ReferenceType type) {
+    private static String getDeclaredType(ReferenceType type, String wrapperPackage) {
         while (true) {
             String typeName = type.name();
 
@@ -423,20 +445,128 @@ public class JdiExpressionEvaluator {
                 }
             }
 
-            // Walk up to find a public supertype the wrapper can reference
+            // Walk up to find a supertype the wrapper can reference: either public, or a non-public
+            // type that shares the wrapper's package (which makes package-private access legal).
             if (type instanceof ClassType classType) {
                 ClassType current = classType;
-                while (current != null && !current.isPublic()) {
+                while (current != null && !isReachableFromWrapper(current, wrapperPackage)) {
                     current = current.superclass();
                 }
                 if (current != null) {
-                    return current.name();
+                    return toSourceTypeName(current.name());
                 }
                 return "java.lang.Object";
             }
 
-            return typeName;
+            return toSourceTypeName(typeName);
         }
+    }
+
+    /**
+     * Whether {@code type} can be referenced by name from a wrapper class living in
+     * {@code wrapperPackage}. True if the type is public, or if it lives in the same package and
+     * is not a local/anonymous class (those are unaddressable from source even within their own
+     * package because their names contain {@code $<digit>} which is not a valid source-form
+     * nested-class separator).
+     */
+    private static boolean isReachableFromWrapper(ClassType type, String wrapperPackage) {
+        if (type.isPublic()) {
+            return true;
+        }
+        if (!packageOf(type.name()).equals(wrapperPackage)) {
+            return false;
+        }
+        return !isLocalOrAnonymous(type.name());
+    }
+
+    /**
+     * Extracts the package portion of a fully qualified binary class name. Returns the empty
+     * string for default-package classes. Treats only the last {@code .} before any {@code $} as
+     * the package/class separator — inner-class {@code $} segments stay attached to the simple
+     * name.
+     */
+    private static String packageOf(String binaryName) {
+        // Stop at the first $ so nested-class binary names like com.example.Outer$Inner still
+        // report "com.example" rather than walking into the nested portion.
+        final int dollar = binaryName.indexOf('$');
+        final String topLevel = dollar < 0 ? binaryName : binaryName.substring(0, dollar);
+        final int dot = topLevel.lastIndexOf('.');
+        return dot < 0 ? "" : topLevel.substring(0, dot);
+    }
+
+    /**
+     * Recognises local-class ({@code Outer$1Local}) and anonymous-class ({@code Outer$1}) binary
+     * names. The JLS only allows nested classes to be referenced from source by their dotted form,
+     * so a binary name where a segment after {@code $} starts with a digit cannot be written as a
+     * Java type reference anywhere — not even from the enclosing class's own package.
+     */
+    private static boolean isLocalOrAnonymous(String binaryName) {
+        int dollar = binaryName.indexOf('$');
+        while (dollar >= 0 && dollar + 1 < binaryName.length()) {
+            if (Character.isDigit(binaryName.charAt(dollar + 1))) {
+                return true;
+            }
+            dollar = binaryName.indexOf('$', dollar + 1);
+        }
+        return false;
+    }
+
+    /**
+     * Converts a JDI binary class name to its Java source form by replacing nested-class
+     * {@code $} separators with {@code .}. Top-level classes (no {@code $}) and dynamic-proxy
+     * names ({@code $$} from CGLIB / Guice / Mockito) pass through unchanged — proxy markers are
+     * NOT nested-class separators and rewriting them produces nonsense like {@code Bar..Mock}.
+     * Local and anonymous classes ({@code $<digit>}) must be filtered upstream; this method
+     * does not reject them because the same conversion is occasionally useful for diagnostics.
+     */
+    private static String toSourceTypeName(String binaryName) {
+        if (binaryName.indexOf('$') < 0 || binaryName.contains("$$")) {
+            return binaryName;
+        }
+        return binaryName.replace('$', '.');
+    }
+
+    /**
+     * Decides which package the generated wrapper class should live in for {@code thisObject}.
+     * Returns {@code thisObject}'s own package when emitting the wrapper there will buy us
+     * additional reachability — i.e. {@code this}'s declared type is non-public AND lives in a
+     * package we are allowed to define new classes in (not {@code java.*} / {@code javax.*},
+     * not a local/anonymous class). Otherwise returns {@link #DEFAULT_EVALUATION_PACKAGE} so the
+     * wrapper stays isolated from app code, matching the pre-existing behaviour.
+     *
+     * <p>Dynamic proxies are unwrapped first so a CGLIB proxy of a package-private service still
+     * resolves to the underlying service's package.
+     */
+    private static String resolveWrapperPackage(@Nullable ObjectReference thisObject) {
+        if (thisObject == null || !(thisObject.referenceType() instanceof ClassType startClass)) {
+            return DEFAULT_EVALUATION_PACKAGE;
+        }
+        // Walk proxies to the real class; reuse the same heuristic as getDeclaredType.
+        ClassType effective = startClass;
+        while (effective != null && effective.name().contains("$$")) {
+            final ClassType next = effective.superclass();
+            if (next == null || "java.lang.Object".equals(next.name())) {
+                break;
+            }
+            effective = next;
+        }
+        if (effective == null || effective.isPublic()) {
+            return DEFAULT_EVALUATION_PACKAGE;
+        }
+        final String binaryName = effective.name();
+        if (isLocalOrAnonymous(binaryName)) {
+            return DEFAULT_EVALUATION_PACKAGE;
+        }
+        final String pkg = packageOf(binaryName);
+        // Refuse to define classes into restricted JDK packages — `java.*` is enforced by the JVM
+        // itself, the rest are flagged here so we get a clean log message rather than a runtime
+        // SecurityException far from the decision site.
+        if (pkg.isEmpty() || pkg.startsWith("java.") || pkg.equals("java")
+            || pkg.startsWith("javax.") || pkg.equals("javax")
+            || pkg.startsWith("sun.") || pkg.startsWith("jdk.")) {
+            return DEFAULT_EVALUATION_PACKAGE;
+        }
+        return pkg;
     }
 
     /**
@@ -534,24 +664,36 @@ public class JdiExpressionEvaluator {
             // NOTE: Classpath configuration must be done BEFORE calling evaluate() to avoid nested JDI calls
             // The caller (e.g., jdwp_evaluate_watchers) is responsible for calling configureCompilerClasspath()
 
+            // 0. Decide which package the wrapper class will live in. For a non-public `this` in an
+            //    addressable package, we emit the wrapper alongside it so package-private fields and
+            //    the type itself become reachable; otherwise we use the default isolated package.
+            final ObjectReference thisObject = frame.thisObject();
+            final String wrapperPackage = resolveWrapperPackage(thisObject);
+
             // 1. Analyze the frame to build the evaluation context
-            final EvaluationContext context = buildContext(frame, extraBindings);
+            final EvaluationContext context = buildContext(frame, extraBindings, wrapperPackage);
 
             // Auto-rewrite bare references to fields of `this` so users can write
             // `sessions.containsKey(session)` instead of `_this.sessions.containsKey(session)`.
-            // Only safe when `this`'s declared type is public AND the specific field is public —
-            // otherwise the wrapper class either can't reference the type or can't access the field,
-            // and we'd just produce a misleading compile error ("not visible" instead of a real hint).
-            final ObjectReference thisObject = frame.thisObject();
-            if (thisObject != null && thisObject.referenceType() instanceof ClassType thisClass && thisClass.isPublic()) {
-                final Set<String> shadowingLocals = context.getVariables().stream()
-                    .map(v -> v.name)
-                    .collect(Collectors.toSet());
-                final Set<String> publicFieldNames = thisClass.allFields().stream()
-                    .filter(Field::isPublic)
-                    .map(Field::name)
-                    .collect(Collectors.toSet());
-                expression = rewriteThisFieldReferences(expression, publicFieldNames, shadowingLocals);
+            // The set of rewritable fields depends on what the wrapper can actually see:
+            //  - When the wrapper lives in the default isolated package, only public fields on a
+            //    public declaring type are reachable.
+            //  - When the wrapper lives in `this`'s own package, public/protected/package-private
+            //    fields are all reachable. Private fields still aren't, so they stay un-rewritten
+            //    and produce a compile error the user can fix (or work around via reflection).
+            if (thisObject != null && thisObject.referenceType() instanceof ClassType thisClass) {
+                final boolean sharingPackage = !wrapperPackage.equals(DEFAULT_EVALUATION_PACKAGE)
+                    && wrapperPackage.equals(packageOf(thisClass.name()));
+                if (thisClass.isPublic() || sharingPackage) {
+                    final Set<String> shadowingLocals = context.getVariables().stream()
+                        .map(v -> v.name)
+                        .collect(Collectors.toSet());
+                    final Set<String> rewritableFieldNames = thisClass.allFields().stream()
+                        .filter(f -> sharingPackage ? !f.isPrivate() : f.isPublic())
+                        .map(Field::name)
+                        .collect(Collectors.toSet());
+                    expression = rewriteThisFieldReferences(expression, rewritableFieldNames, shadowingLocals);
+                }
             }
 
             // 2. Use cache key based on context + expression (excludes UUID for cache hits)
@@ -577,7 +719,7 @@ public class JdiExpressionEvaluator {
             } else {
                 // Cache miss — generate unique class name, compile, and cache
                 final String uniqueId = UUID.randomUUID().toString().replace("-", "");
-                className = EVALUATION_PACKAGE + '.' + EVALUATION_CLASS_PREFIX + uniqueId;
+                className = wrapperPackage + '.' + EVALUATION_CLASS_PREFIX + uniqueId;
 
                 final String sourceCode = generateSourceCode(className, context, expression);
 

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
@@ -465,18 +465,49 @@ public class JdiExpressionEvaluator {
     /**
      * Whether {@code type} can be referenced by name from a wrapper class living in
      * {@code wrapperPackage}. True if the type is public, or if it lives in the same package and
-     * is not a local/anonymous class (those are unaddressable from source even within their own
-     * package because their names contain {@code $<digit>} which is not a valid source-form
-     * nested-class separator).
+     * is neither {@code private} nor a local/anonymous class. Private nested classes are
+     * accessible only from inside their enclosing class — even another top-level class in the
+     * same package can't reach them — so they walk to a public supertype like any other
+     * unreachable case. Local/anonymous classes ({@code $<digit>} in the binary name) are
+     * unaddressable from source anywhere.
      */
     private static boolean isReachableFromWrapper(ClassType type, String wrapperPackage) {
         if (type.isPublic()) {
             return true;
         }
+        if (type.isPrivate()) {
+            return false;
+        }
         if (!packageOf(type.name()).equals(wrapperPackage)) {
             return false;
         }
         return !isLocalOrAnonymous(type.name());
+    }
+
+    /**
+     * Whether {@code field} can be referenced from the generated wrapper class, given the
+     * wrapper's package and whether it shares that package with {@code this}'s declared type.
+     * <ul>
+     *   <li>{@code public} fields are always reachable.</li>
+     *   <li>When the wrapper does NOT share {@code this}'s package, only public fields are
+     *       reachable — the wrapper is in the isolated {@code mcp.jdi.evaluation} and cannot see
+     *       package-private or protected members of app code.</li>
+     *   <li>When the wrapper DOES share {@code this}'s package, non-private fields are reachable
+     *       only if their declaring type ALSO lives in that package. A protected field inherited
+     *       from a class in a different package is accessible only via subclassing, and the
+     *       wrapper is not a subclass — so we leave such fields un-rewritten to avoid a
+     *       misleading "not visible" compile error.</li>
+     *   <li>Private fields are never rewritten (the wrapper is not the declaring class).</li>
+     * </ul>
+     */
+    private static boolean isFieldAccessibleFromWrapper(Field field, String wrapperPackage, boolean sharingPackage) {
+        if (field.isPublic()) {
+            return true;
+        }
+        if (!sharingPackage || field.isPrivate()) {
+            return false;
+        }
+        return packageOf(field.declaringType().name()).equals(wrapperPackage);
     }
 
     /**
@@ -513,9 +544,17 @@ public class JdiExpressionEvaluator {
 
     /**
      * Converts a JDI binary class name to its Java source form by replacing nested-class
-     * {@code $} separators with {@code .}. Top-level classes (no {@code $}) and dynamic-proxy
-     * names ({@code $$} from CGLIB / Guice / Mockito) pass through unchanged — proxy markers are
-     * NOT nested-class separators and rewriting them produces nonsense like {@code Bar..Mock}.
+     * {@code $} separators with {@code .}. Only rewrites a {@code $} when it is a genuine
+     * nested-class separator: preceded AND followed by a non-{@code $} Java identifier part,
+     * and not immediately after a {@code .}. Specifically left unchanged:
+     * <ul>
+     *   <li>Dynamic-proxy names containing {@code $$} (CGLIB / Guice / Mockito) — proxy markers
+     *       are not nested separators; rewriting produces nonsense like {@code Bar..Mock}.</li>
+     *   <li>JDK dynamic-proxy names like {@code com.sun.proxy.$Proxy12} where {@code $} starts a
+     *       simple-name component (preceded by {@code .}); rewriting would yield the invalid
+     *       {@code com.sun.proxy..Proxy12}.</li>
+     *   <li>Names where {@code $} sits at the start or end of the binary name.</li>
+     * </ul>
      * Local and anonymous classes ({@code $<digit>}) must be filtered upstream; this method
      * does not reject them because the same conversion is occasionally useful for diagnostics.
      */
@@ -523,7 +562,37 @@ public class JdiExpressionEvaluator {
         if (binaryName.indexOf('$') < 0 || binaryName.contains("$$")) {
             return binaryName;
         }
-        return binaryName.replace('$', '.');
+        final int n = binaryName.length();
+        final StringBuilder sb = new StringBuilder(n);
+        for (int i = 0; i < n; i++) {
+            final char c = binaryName.charAt(i);
+            if (c == '$' && isNestedClassSeparator(binaryName, i)) {
+                sb.append('.');
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Returns {@code true} when the {@code $} at {@code pos} in {@code name} is a genuine
+     * nested-class separator (i.e. the form emitted by {@code javac} for {@code Outer.Inner}
+     * compiled to {@code Outer$Inner}) and not, e.g., the leading {@code $} of a JDK dynamic-proxy
+     * simple name. Helper for {@link #toSourceTypeName}.
+     */
+    private static boolean isNestedClassSeparator(String name, int pos) {
+        if (pos == 0 || pos == name.length() - 1) {
+            return false;
+        }
+        final char prev = name.charAt(pos - 1);
+        final char next = name.charAt(pos + 1);
+        // `prev == '.'` covers `com.sun.proxy.$Proxy12` and similar JDK proxy forms.
+        // `prev`/`next == '$'` covers adjacent proxy `$$` (the contains-check above already
+        // short-circuits the typical case, but stays defensive against future name shapes).
+        return prev != '.' && prev != '$' && next != '$'
+            && Character.isJavaIdentifierPart(prev)
+            && Character.isJavaIdentifierPart(next);
     }
 
     /**
@@ -629,9 +698,12 @@ public class JdiExpressionEvaluator {
     /**
      * Evaluates `expression` in the context of `frame` plus any caller-supplied synthetic bindings,
      * and returns the result as a JDI {@link Value}. Side effect: populates {@link #compilationCache}.
-     * The auto-rewrite of bare `this.field` references only runs when `this`'s declared type is
-     * public — for non-public types the wrapper class can't reference the type at all, so the
-     * rewrite would just produce a misleading "type not visible" error.
+     *
+     * <p>The auto-rewrite of bare {@code this.field} references runs when EITHER {@code this}'s
+     * declared type is public OR the wrapper is emitted into {@code this}'s own package (see
+     * {@link #resolveWrapperPackage}). In the latter case package-private and protected fields
+     * also become candidates — subject to {@link #isFieldAccessibleFromWrapper}'s per-field
+     * accessibility check.
      *
      * <p>Synthetic bindings (e.g. {@code "$exception" -> ObjectReference}) appear in the wrapper's
      * parameter list after the real locals and can be referenced by name in the expression. This is
@@ -675,12 +747,15 @@ public class JdiExpressionEvaluator {
 
             // Auto-rewrite bare references to fields of `this` so users can write
             // `sessions.containsKey(session)` instead of `_this.sessions.containsKey(session)`.
-            // The set of rewritable fields depends on what the wrapper can actually see:
+            // Each candidate field is filtered for accessibility from the wrapper class:
             //  - When the wrapper lives in the default isolated package, only public fields on a
             //    public declaring type are reachable.
             //  - When the wrapper lives in `this`'s own package, public/protected/package-private
-            //    fields are all reachable. Private fields still aren't, so they stay un-rewritten
-            //    and produce a compile error the user can fix (or work around via reflection).
+            //    fields are reachable PROVIDED the field's declaring type ALSO lives in that
+            //    package. A protected field inherited from a class in some other package is not
+            //    accessible from a non-subclass even when `this`'s runtime type is in the wrapper
+            //    package — so we'd produce a misleading "not visible" error if we rewrote it.
+            //  - Private fields are never rewritten.
             if (thisObject != null && thisObject.referenceType() instanceof ClassType thisClass) {
                 final boolean sharingPackage = !wrapperPackage.equals(DEFAULT_EVALUATION_PACKAGE)
                     && wrapperPackage.equals(packageOf(thisClass.name()));
@@ -689,7 +764,7 @@ public class JdiExpressionEvaluator {
                         .map(v -> v.name)
                         .collect(Collectors.toSet());
                     final Set<String> rewritableFieldNames = thisClass.allFields().stream()
-                        .filter(f -> sharingPackage ? !f.isPrivate() : f.isPublic())
+                        .filter(f -> isFieldAccessibleFromWrapper(f, wrapperPackage, sharingPackage))
                         .map(Field::name)
                         .collect(Collectors.toSet());
                     expression = rewriteThisFieldReferences(expression, rewritableFieldNames, shadowingLocals);

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/RemoteCodeExecutor.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/RemoteCodeExecutor.java
@@ -1,6 +1,7 @@
 package one.edee.mcp.jdwp.evaluation;
 
 import com.sun.jdi.*;
+import one.edee.mcp.jdwp.evaluation.exceptions.JdiClassDefinitionException;
 import one.edee.mcp.jdwp.evaluation.exceptions.JdiEvaluationException;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -100,6 +101,11 @@ public final class RemoteCodeExecutor {
             final String exceptionType = exception != null ? exception.type().name() : "unknown";
             log.error("[Executor] Target VM threw exception after {}ms: {}", elapsed, exceptionType, e);
             throw new JdiEvaluationException("Target VM threw exception: " + exceptionType, e);
+        } catch (JdiEvaluationException e) {
+            // Already classified by a lower phase (notably loadClass's JdiClassDefinitionException).
+            // Propagate unchanged so the evaluator can act on the precise subtype — re-wrapping here
+            // would erase the define-vs-invoke distinction the package-fallback retry depends on.
+            throw e;
         } catch (Exception e) {
             final long elapsed = System.currentTimeMillis() - startTime;
             log.error("[Executor] Unexpected exception after {}ms: {}", elapsed, e.getClass().getName(), e);
@@ -166,12 +172,12 @@ public final class RemoteCodeExecutor {
 
         } catch (InvalidTypeException | ClassNotLoadedException | IncompatibleThreadStateException e) {
             log.error("[Executor] Failed to load class {}: {}", className, e.getClass().getSimpleName(), e);
-            throw new JdiEvaluationException("Failed to load class '" + className + "' into target VM: " + e.getMessage(), e);
+            throw new JdiClassDefinitionException("Failed to load class '" + className + "' into target VM: " + e.getMessage(), e);
         } catch (InvocationException e) {
             final ObjectReference exception = e.exception();
             final String exceptionType = exception != null ? exception.type().name() : "unknown";
             log.error("[Executor] defineClass threw exception {}: {}", exceptionType, e.getMessage(), e);
-            throw new JdiEvaluationException("Failed to load class '" + className + "': " + exceptionType, e);
+            throw new JdiClassDefinitionException("Failed to load class '" + className + "': " + exceptionType, e);
         }
     }
 

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/exceptions/JdiClassDefinitionException.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/exceptions/JdiClassDefinitionException.java
@@ -1,0 +1,30 @@
+package one.edee.mcp.jdwp.evaluation.exceptions;
+
+import one.edee.mcp.jdwp.evaluation.RemoteCodeExecutor;
+
+import java.io.Serial;
+
+/**
+ * Raised exclusively by {@link RemoteCodeExecutor} when <em>defining</em> the wrapper class into the
+ * target VM fails — i.e. before the user's expression has run. Distinct from the base
+ * {@link JdiEvaluationException} (which also covers user-code failures from the wrapper's
+ * {@code invokeMethod}) so callers can safely retry the define step in a different package without
+ * risking double execution of a side-effecting expression: a define failure guarantees the user
+ * code never executed.
+ * <p>
+ * The motivating case is the target-package wrapper feature: when {@code this} is non-public, the
+ * wrapper is emitted into {@code this}'s own package so package-private members are reachable. If
+ * {@code ClassLoader.defineClass} rejects that package at runtime (sealed package, module
+ * encapsulation, a restrictive custom classloader), {@link one.edee.mcp.jdwp.evaluation.JdiExpressionEvaluator}
+ * retries once in the default isolated package to preserve the pre-feature behaviour for
+ * public-only expressions.
+ */
+public class JdiClassDefinitionException extends JdiEvaluationException {
+
+    @Serial
+    private static final long serialVersionUID = 7128658239011934401L;
+
+    public JdiClassDefinitionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorGetDeclaredTypeTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorGetDeclaredTypeTest.java
@@ -315,14 +315,16 @@ class JdiExpressionEvaluatorGetDeclaredTypeTest {
 		}
 
 		@Test
-		@DisplayName("diamond superinterface graph — visited-guard prevents infinite recursion")
+		@DisplayName("diamond superinterface graph — visited-guard avoids re-expanding the shared parent")
 		void shouldTerminateOnDiamondInheritance() throws Exception {
 			InterfaceType pub = mock(InterfaceType.class);
 			when(pub.name()).thenReturn("com.example.Root");
 			when(pub.isPublic()).thenReturn(true);
 
 			// Two non-public mid-level interfaces both extend the same public Root (a diamond when
-			// a leaf extends both). The visited set must stop Root being re-expanded endlessly.
+			// a leaf extends both). Interface inheritance is acyclic, so the walk terminates even
+			// without the visited set; the set's job here is to avoid re-expanding the shared Root
+			// twice (and to stay safe against pathological/cyclic inputs).
 			InterfaceType left = mock(InterfaceType.class);
 			when(left.name()).thenReturn("com.elsewhere.Left");
 			when(left.isPublic()).thenReturn(false);

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorGetDeclaredTypeTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorGetDeclaredTypeTest.java
@@ -16,12 +16,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Tests {@link JdiExpressionEvaluator}'s private {@code getDeclaredType(ReferenceType)} helper.
- * This routine resolves the type name the wrapper class should reference, taking care of
- * dynamic proxies (CGLIB / Guice / Mockito {@code $$}) and non-public types (walks up to a
- * public supertype, falling back to {@code java.lang.Object}).
+ * Tests {@link JdiExpressionEvaluator}'s private
+ * {@code getDeclaredType(ReferenceType, String)} helper. This routine resolves the type name
+ * the wrapper class should reference, taking care of dynamic proxies (CGLIB / Guice / Mockito
+ * {@code $$}) and non-public types (walks up to a public supertype, or to a same-package type
+ * the wrapper can see by being emitted into that package, falling back to {@code java.lang.Object}).
  */
 class JdiExpressionEvaluatorGetDeclaredTypeTest {
+
+	/**
+	 * The default isolated wrapper package — passing this disables the "share package with target"
+	 * shortcut and exercises the legacy walk-to-public-supertype behaviour.
+	 */
+	private static final String DEFAULT_WRAPPER_PACKAGE = "mcp.jdi.evaluation";
 
 	private JdiExpressionEvaluator evaluator;
 
@@ -143,8 +150,72 @@ class JdiExpressionEvaluatorGetDeclaredTypeTest {
 	}
 
 	private String invokeGetDeclaredType(ReferenceType type) throws Exception {
+		return invokeGetDeclaredType(type, DEFAULT_WRAPPER_PACKAGE);
+	}
+
+	private String invokeGetDeclaredType(ReferenceType type, String wrapperPackage) throws Exception {
 		return TestReflectionUtils.invokePrivate(
 			evaluator, "getDeclaredType",
-			new Class[]{ReferenceType.class}, type);
+			new Class[]{ReferenceType.class, String.class}, type, wrapperPackage);
+	}
+
+	@Nested
+	@DisplayName("Wrapper-shares-package mode")
+	class WrapperSharesPackage {
+
+		@Test
+		@DisplayName("non-public type in wrapper package — returned as-is")
+		void shouldReturnNonPublicTypeWhenWrapperSharesPackage() throws Exception {
+			ClassType type = mock(ClassType.class);
+			when(type.name()).thenReturn("com.example.PackagePrivate");
+			when(type.isPublic()).thenReturn(false);
+			// No need to mock superclass — the same-package check short-circuits the walk.
+
+			assertThat(invokeGetDeclaredType(type, "com.example")).isEqualTo("com.example.PackagePrivate");
+		}
+
+		@Test
+		@DisplayName("non-public type in OTHER package — still walks up to public supertype")
+		void shouldStillWalkUpWhenWrapperPackageDiffers() throws Exception {
+			ClassType pub = mock(ClassType.class);
+			when(pub.name()).thenReturn("com.example.PublicAncestor");
+			when(pub.isPublic()).thenReturn(true);
+
+			ClassType type = mock(ClassType.class);
+			when(type.name()).thenReturn("com.elsewhere.Hidden");
+			when(type.isPublic()).thenReturn(false);
+			when(type.superclass()).thenReturn(pub);
+
+			assertThat(invokeGetDeclaredType(type, "com.example"))
+				.isEqualTo("com.example.PublicAncestor");
+		}
+
+		@Test
+		@DisplayName("nested-class binary name — `$` is rewritten to `.` in the source form")
+		void shouldRewriteNestedClassDollarToDot() throws Exception {
+			ClassType type = mock(ClassType.class);
+			when(type.name()).thenReturn("com.example.Outer$Inner");
+			when(type.isPublic()).thenReturn(true);
+
+			assertThat(invokeGetDeclaredType(type, "com.example"))
+				.isEqualTo("com.example.Outer.Inner");
+		}
+
+		@Test
+		@DisplayName("anonymous-class binary name — refuses to expose, walks to a public supertype")
+		void shouldNotExposeAnonymousClass() throws Exception {
+			ClassType pub = mock(ClassType.class);
+			when(pub.name()).thenReturn("com.example.Public");
+			when(pub.isPublic()).thenReturn(true);
+
+			// `Outer$1` is an anonymous class — JLS does not let any class reference it by name,
+			// including from its own package. The walk should keep going up to the public ancestor.
+			ClassType anon = mock(ClassType.class);
+			when(anon.name()).thenReturn("com.example.Outer$1");
+			when(anon.isPublic()).thenReturn(false);
+			when(anon.superclass()).thenReturn(pub);
+
+			assertThat(invokeGetDeclaredType(anon, "com.example")).isEqualTo("com.example.Public");
+		}
 	}
 }

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorGetDeclaredTypeTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorGetDeclaredTypeTest.java
@@ -25,8 +25,10 @@ import static org.mockito.Mockito.when;
 class JdiExpressionEvaluatorGetDeclaredTypeTest {
 
 	/**
-	 * The default isolated wrapper package — passing this disables the "share package with target"
-	 * shortcut and exercises the legacy walk-to-public-supertype behaviour.
+	 * The default isolated wrapper package — passing this exercises the legacy
+	 * walk-to-public-supertype behaviour for typical target types. A non-public type whose package
+	 * happens to literally equal {@code mcp.jdi.evaluation} would still trigger the share-package
+	 * shortcut; the tests don't exercise that theoretical edge case.
 	 */
 	private static final String DEFAULT_WRAPPER_PACKAGE = "mcp.jdi.evaluation";
 
@@ -216,6 +218,43 @@ class JdiExpressionEvaluatorGetDeclaredTypeTest {
 			when(anon.superclass()).thenReturn(pub);
 
 			assertThat(invokeGetDeclaredType(anon, "com.example")).isEqualTo("com.example.Public");
+		}
+
+		@Test
+		@DisplayName("private nested class in wrapper package — NOT reachable, walks to a public supertype")
+		void shouldNotExposePrivateNestedClassEvenInSamePackage() throws Exception {
+			ClassType pub = mock(ClassType.class);
+			when(pub.name()).thenReturn("com.example.Public");
+			when(pub.isPublic()).thenReturn(true);
+
+			// A private nested class is accessible only from its enclosing class — even another
+			// top-level class in the same package cannot reference it. The walk should skip past it.
+			ClassType priv = mock(ClassType.class);
+			when(priv.name()).thenReturn("com.example.Outer$PrivateInner");
+			when(priv.isPublic()).thenReturn(false);
+			when(priv.isPrivate()).thenReturn(true);
+			when(priv.superclass()).thenReturn(pub);
+
+			assertThat(invokeGetDeclaredType(priv, "com.example")).isEqualTo("com.example.Public");
+		}
+	}
+
+	@Nested
+	@DisplayName("JDK dynamic-proxy binary names")
+	class JdkDynamicProxy {
+
+		@Test
+		@DisplayName("`com.sun.proxy.$Proxy12` — leading-$ simple name is NOT rewritten to `..Proxy12`")
+		void shouldNotRewriteJdkDynamicProxyName() throws Exception {
+			// JDK java.lang.reflect.Proxy generates classes like `com.sun.proxy.$Proxy12`. The `$`
+			// is part of the simple-name component, NOT a nested-class separator — rewriting it
+			// to `.` would yield the invalid name `com.sun.proxy..Proxy12` and break wrapper
+			// compilation.
+			ClassType proxy = mock(ClassType.class);
+			when(proxy.name()).thenReturn("com.sun.proxy.$Proxy12");
+			when(proxy.isPublic()).thenReturn(true);
+
+			assertThat(invokeGetDeclaredType(proxy)).isEqualTo("com.sun.proxy.$Proxy12");
 		}
 	}
 }

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorGetDeclaredTypeTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorGetDeclaredTypeTest.java
@@ -2,6 +2,7 @@ package one.edee.mcp.jdwp.evaluation;
 
 import com.sun.jdi.ArrayType;
 import com.sun.jdi.ClassType;
+import com.sun.jdi.InterfaceType;
 import com.sun.jdi.ReferenceType;
 import one.edee.mcp.jdwp.EvaluationGuard;
 import one.edee.mcp.jdwp.JDIConnectionService;
@@ -10,6 +11,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
@@ -255,6 +258,87 @@ class JdiExpressionEvaluatorGetDeclaredTypeTest {
 			when(proxy.isPublic()).thenReturn(true);
 
 			assertThat(invokeGetDeclaredType(proxy)).isEqualTo("com.sun.proxy.$Proxy12");
+		}
+	}
+
+	@Nested
+	@DisplayName("Interface types")
+	class InterfaceTypes {
+
+		@Test
+		@DisplayName("public interface — returned as-is")
+		void shouldReturnPublicInterfaceDirectly() throws Exception {
+			InterfaceType type = mock(InterfaceType.class);
+			when(type.name()).thenReturn("com.example.Service");
+			when(type.isPublic()).thenReturn(true);
+
+			assertThat(invokeGetDeclaredType(type)).isEqualTo("com.example.Service");
+		}
+
+		@Test
+		@DisplayName("non-public interface in OTHER package — walks superinterfaces to a public one")
+		void shouldWalkToPublicSuperinterface() throws Exception {
+			InterfaceType pub = mock(InterfaceType.class);
+			when(pub.name()).thenReturn("com.example.PublicApi");
+			when(pub.isPublic()).thenReturn(true);
+
+			InterfaceType pkgPrivate = mock(InterfaceType.class);
+			when(pkgPrivate.name()).thenReturn("com.elsewhere.Internal");
+			when(pkgPrivate.isPublic()).thenReturn(false);
+			when(pkgPrivate.superinterfaces()).thenReturn(List.of(pub));
+
+			assertThat(invokeGetDeclaredType(pkgPrivate, "com.example"))
+				.isEqualTo("com.example.PublicApi");
+		}
+
+		@Test
+		@DisplayName("non-public interface with no reachable superinterface — falls back to Object")
+		void shouldFallBackToObjectWhenNoReachableSuperinterface() throws Exception {
+			InterfaceType only = mock(InterfaceType.class);
+			when(only.name()).thenReturn("com.elsewhere.Internal");
+			when(only.isPublic()).thenReturn(false);
+			when(only.superinterfaces()).thenReturn(List.of());
+
+			assertThat(invokeGetDeclaredType(only, "com.example")).isEqualTo("java.lang.Object");
+		}
+
+		@Test
+		@DisplayName("non-public interface in wrapper package — exposed by its own name")
+		void shouldExposeNonPublicInterfaceWhenWrapperSharesPackage() throws Exception {
+			InterfaceType type = mock(InterfaceType.class);
+			when(type.name()).thenReturn("com.example.PackagePrivateApi");
+			when(type.isPublic()).thenReturn(false);
+			// superinterfaces() is never consulted — the same-package check accepts it first.
+
+			assertThat(invokeGetDeclaredType(type, "com.example"))
+				.isEqualTo("com.example.PackagePrivateApi");
+		}
+
+		@Test
+		@DisplayName("diamond superinterface graph — visited-guard prevents infinite recursion")
+		void shouldTerminateOnDiamondInheritance() throws Exception {
+			InterfaceType pub = mock(InterfaceType.class);
+			when(pub.name()).thenReturn("com.example.Root");
+			when(pub.isPublic()).thenReturn(true);
+
+			// Two non-public mid-level interfaces both extend the same public Root (a diamond when
+			// a leaf extends both). The visited set must stop Root being re-expanded endlessly.
+			InterfaceType left = mock(InterfaceType.class);
+			when(left.name()).thenReturn("com.elsewhere.Left");
+			when(left.isPublic()).thenReturn(false);
+			when(left.superinterfaces()).thenReturn(List.of(pub));
+
+			InterfaceType right = mock(InterfaceType.class);
+			when(right.name()).thenReturn("com.elsewhere.Right");
+			when(right.isPublic()).thenReturn(false);
+			when(right.superinterfaces()).thenReturn(List.of(pub));
+
+			InterfaceType leaf = mock(InterfaceType.class);
+			when(leaf.name()).thenReturn("com.elsewhere.Leaf");
+			when(leaf.isPublic()).thenReturn(false);
+			when(leaf.superinterfaces()).thenReturn(List.of(left, right));
+
+			assertThat(invokeGetDeclaredType(leaf, "com.example")).isEqualTo("com.example.Root");
 		}
 	}
 }

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorPackageFallbackTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorPackageFallbackTest.java
@@ -1,0 +1,144 @@
+package one.edee.mcp.jdwp.evaluation;
+
+import com.sun.jdi.ClassLoaderReference;
+import com.sun.jdi.ClassType;
+import com.sun.jdi.ObjectReference;
+import com.sun.jdi.StackFrame;
+import com.sun.jdi.ThreadReference;
+import com.sun.jdi.Value;
+import com.sun.jdi.VirtualMachine;
+import one.edee.mcp.jdwp.EvaluationGuard;
+import one.edee.mcp.jdwp.JDIConnectionService;
+import one.edee.mcp.jdwp.evaluation.exceptions.JdiClassDefinitionException;
+import one.edee.mcp.jdwp.evaluation.exceptions.JdiEvaluationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+/**
+ * Covers the define-phase package fallback in {@link JdiExpressionEvaluator#evaluate}: when the
+ * wrapper cannot be DEFINED into a non-public {@code this}'s own package (sealed package / module
+ * encapsulation / restrictive classloader, surfaced as {@link JdiClassDefinitionException}), the
+ * evaluator retries once in the default isolated package. A define-phase failure means the user
+ * expression never ran, so the retry cannot double-execute a side-effecting expression — which is
+ * why only {@link JdiClassDefinitionException} (not a generic user-code failure) triggers it.
+ */
+class JdiExpressionEvaluatorPackageFallbackTest {
+
+	private static final String DEFAULT_PACKAGE = "mcp.jdi.evaluation";
+
+	private InMemoryJavaCompiler compiler;
+	private JdiExpressionEvaluator evaluator;
+	private StackFrame frame;
+	private ClassType thisType;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		compiler = mock(InMemoryJavaCompiler.class);
+		final JDIConnectionService jdiService = mock(JDIConnectionService.class);
+		evaluator = new JdiExpressionEvaluator(compiler, jdiService, new EvaluationGuard());
+		// Compiler is mocked — echo back the requested class name so the bytecode lookup hits.
+		when(compiler.compile(anyString(), anyString()))
+			.thenAnswer(inv -> Map.of(inv.getArgument(0, String.class), new byte[]{1, 2, 3}));
+	}
+
+	/**
+	 * Wires a minimal frame whose {@code this} runtime type is {@code com.app.Foo}.
+	 *
+	 * @param publicThis when false, {@code this} is non-public so the evaluator targets
+	 *                   {@code com.app}; when true, {@code this} is public so it targets the
+	 *                   default package (no fallback possible).
+	 */
+	private void wireFrame(boolean publicThis) throws Exception {
+		frame = mock(StackFrame.class);
+		final ThreadReference thread = mock(ThreadReference.class);
+		when(thread.uniqueID()).thenReturn(1L);
+		when(frame.thread()).thenReturn(thread);
+		when(frame.virtualMachine()).thenReturn(mock(VirtualMachine.class));
+		when(frame.visibleVariables()).thenReturn(List.of());
+
+		final ObjectReference thisRef = mock(ObjectReference.class);
+		thisType = mock(ClassType.class);
+		when(thisType.name()).thenReturn("com.app.Foo");
+		when(thisType.isPublic()).thenReturn(publicThis);
+		when(thisType.allFields()).thenReturn(List.of());
+		when(thisType.classLoader()).thenReturn(mock(ClassLoaderReference.class));
+		when(thisRef.referenceType()).thenReturn(thisType);
+		when(frame.thisObject()).thenReturn(thisRef);
+	}
+
+	@Test
+	@DisplayName("define failure in the target package retries once in the default package")
+	void shouldRetryInDefaultPackageWhenDefineFailsInTargetPackage() throws Exception {
+		wireFrame(false); // non-public this → wrapper targets com.app
+		final Value expected = mock(Value.class);
+
+		try (MockedStatic<RemoteCodeExecutor> mocked = mockStatic(RemoteCodeExecutor.class)) {
+			mocked.when(() -> RemoteCodeExecutor.execute(any(), any(), any(), anyString(), any(), anyString(), anyList()))
+				.thenAnswer(inv -> {
+					final String className = inv.getArgument(3, String.class);
+					if (className.startsWith("com.app.")) {
+						throw new JdiClassDefinitionException("Prohibited package name: com.app", new RuntimeException());
+					}
+					return expected;
+				});
+
+			final Value result = evaluator.evaluate(frame, "1 + 1", Map.of());
+
+			assertThat(result).isSameAs(expected);
+			// Two binds: the rejected com.app attempt, then the successful default-package retry.
+			mocked.verify(() -> RemoteCodeExecutor.execute(any(), any(), any(), anyString(), any(), anyString(), anyList()),
+				times(2));
+		}
+	}
+
+	@Test
+	@DisplayName("define failure already in the default package is NOT retried")
+	void shouldNotRetryWhenDefineFailsInDefaultPackage() throws Exception {
+		wireFrame(true); // public this → wrapper already targets the default package
+
+		try (MockedStatic<RemoteCodeExecutor> mocked = mockStatic(RemoteCodeExecutor.class)) {
+			mocked.when(() -> RemoteCodeExecutor.execute(any(), any(), any(), anyString(), any(), anyString(), anyList()))
+				.thenThrow(new JdiClassDefinitionException("defineClass blocked", new RuntimeException()));
+
+			assertThatThrownBy(() -> evaluator.evaluate(frame, "1 + 1", Map.of()))
+				.isInstanceOf(JdiEvaluationException.class);
+
+			mocked.verify(() -> RemoteCodeExecutor.execute(any(), any(), any(), anyString(), any(), anyString(), anyList()),
+				times(1));
+		}
+	}
+
+	@Test
+	@DisplayName("a user-code failure (not a define failure) is NOT retried, even in the target package")
+	void shouldNotRetryOnUserCodeFailure() throws Exception {
+		wireFrame(false); // non-public this → target package, so a retry WOULD be possible if mis-triggered
+
+		try (MockedStatic<RemoteCodeExecutor> mocked = mockStatic(RemoteCodeExecutor.class)) {
+			// Plain JdiEvaluationException models the user's expression throwing — must not retry,
+			// otherwise a side-effecting expression would run twice.
+			mocked.when(() -> RemoteCodeExecutor.execute(any(), any(), any(), anyString(), any(), anyString(), anyList()))
+				.thenThrow(new JdiEvaluationException("Target VM threw exception: java.lang.NullPointerException"));
+
+			assertThatThrownBy(() -> evaluator.evaluate(frame, "this.x.length()", Map.of()))
+				.isInstanceOf(JdiEvaluationException.class);
+
+			mocked.verify(() -> RemoteCodeExecutor.execute(any(), any(), any(), anyString(), any(), anyString(), anyList()),
+				times(1));
+		}
+	}
+}

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorPackageFallbackTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorPackageFallbackTest.java
@@ -39,12 +39,9 @@ import static org.mockito.Mockito.when;
  */
 class JdiExpressionEvaluatorPackageFallbackTest {
 
-	private static final String DEFAULT_PACKAGE = "mcp.jdi.evaluation";
-
 	private InMemoryJavaCompiler compiler;
 	private JdiExpressionEvaluator evaluator;
 	private StackFrame frame;
-	private ClassType thisType;
 
 	@BeforeEach
 	void setUp() throws Exception {
@@ -72,7 +69,7 @@ class JdiExpressionEvaluatorPackageFallbackTest {
 		when(frame.visibleVariables()).thenReturn(List.of());
 
 		final ObjectReference thisRef = mock(ObjectReference.class);
-		thisType = mock(ClassType.class);
+		final ClassType thisType = mock(ClassType.class);
 		when(thisType.name()).thenReturn("com.app.Foo");
 		when(thisType.isPublic()).thenReturn(publicThis);
 		when(thisType.allFields()).thenReturn(List.of());


### PR DESCRIPTION
Closes #7.

## Summary
Generated wrapper classes used by the expression evaluator now live in **the target type's own package** when `this` is non-public, so package-private fields and non-public types become reachable instead of being short-circuited to a public supertype.

## How
- `resolveWrapperPackage(thisObject)` decides whether to emit into `this`'s package (non-public + addressable) or fall back to the isolated `mcp.jdi.evaluation`.
- `getDeclaredType(ReferenceType, wrapperPackage)` now treats same-package non-public types as reachable, returning their real name (with `$` → `.` for nested classes, `$$` proxy markers preserved).
- The auto-rewrite of `this.field` → `_this.field` widens to include public/protected/package-private fields in shared-package mode. Private fields stay un-rewritten.
- Restricted packages (`java.*`, `javax.*`, `sun.*`, `jdk.*`) and local/anonymous classes route back to the default isolated package.

## Test plan
- [x] `./mvnw -pl jdwp-mcp-server test` — 904 tests pass (4 new in `JdiExpressionEvaluatorGetDeclaredTypeTest`)
- [x] Compile clean — no new NullAway / Error Prone warnings
- [ ] Test flight against a target VM with a package-private `this` to confirm the wrapper compiles + executes in the target module (defineClass into a named module is environment-dependent — works for non-modular Spring Boot apps, may need follow-up for fully modularized targets).

## Risk
The big unknown is **modular Java apps**: `ClassLoader.defineClass(name, bytes, 0, len)` places the wrapper into the classloader's unnamed module unless the target package is registered with a named module. In modular targets where `com.example` is a named module, the wrapper may end up in the unnamed module and lose package-private access. The fallback is the existing isolated-package behavior + a public-supertype walk, so the worst case is "same compile error as before".