### PR TITLE
fix: harden classpath-warming lifecycle for expression evaluation

### DIFF
--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JdiEventListener.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/JdiEventListener.java
@@ -340,23 +340,38 @@ public class JdiEventListener {
                     }
                 }
                 boolean shouldSuspend = false;
+                // First thread parked for inspection in this set; used to pre-warm the compiler
+                // classpath once the loop has recorded the hit (see the prewarm call below).
+                ThreadReference warmThread = null;
 
                 for (Event event : eventSet) {
                     if (event instanceof BreakpointEvent bpEvent) {
                         if (handleBreakpointEvent(bpEvent)) {
                             shouldSuspend = true;
+                            if (warmThread == null) {
+                                warmThread = bpEvent.thread();
+                            }
                         }
                     } else if (event instanceof StepEvent stepEvent) {
                         if (handleStepEvent(stepEvent)) {
                             shouldSuspend = true;
+                            if (warmThread == null) {
+                                warmThread = stepEvent.thread();
+                            }
                         }
                     } else if (event instanceof ExceptionEvent exEvent) {
                         if (handleExceptionEvent(exEvent)) {
                             shouldSuspend = true;
+                            if (warmThread == null) {
+                                warmThread = exEvent.thread();
+                            }
                         }
                     } else if (event instanceof WatchpointEvent wpEvent) {
                         if (handleWatchpointEvent(wpEvent)) {
                             shouldSuspend = true;
+                            if (warmThread == null) {
+                                warmThread = wpEvent.thread();
+                            }
                         }
                     } else if (event instanceof ClassPrepareEvent cpEvent) {
                         handleClassPrepareEvent(cpEvent);
@@ -376,7 +391,20 @@ public class JdiEventListener {
                     }
                 }
 
-                if (!shouldSuspend) {
+                if (shouldSuspend) {
+                    // The set stays parked for inspection. Pre-warm the compiler classpath now, on
+                    // the first suspending thread, so the agent's first evaluate_expression (or the
+                    // first logpoint/condition hit) does not pay the one-time ~1-3s discovery cost on
+                    // its critical path. Runs only on the first stop per connection — thereafter the
+                    // discovered JDK path short-circuits prewarmClasspath. Never throws (warming
+                    // failures are logged and retried by the real evaluation call). It is safe to
+                    // drive invokeMethod from here for the same reason logpoint evaluation is: the
+                    // prohibition is on event-dispatch callbacks, not on invocations made while the
+                    // listener processes a drained event.
+                    if (warmThread != null) {
+                        expressionEvaluator.prewarmClasspath(warmThread);
+                    }
+                } else {
                     eventSet.resume();
                 }
             } catch (InterruptedException e) {

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/InMemoryJavaCompiler.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/InMemoryJavaCompiler.java
@@ -106,6 +106,21 @@ public class InMemoryJavaCompiler {
     }
 
     /**
+     * Returns the compiler to its unconfigured state, dropping the JDK path and classpath set by
+     * {@link #configure} and restoring the default target version. Called on disconnect/reconnect:
+     * the discovered classpath belongs to one specific target VM, so leftover config from a previous
+     * connection must not survive. Without this, a post-reconnect discovery failure would leave
+     * {@link #jdkPath} non-null and {@link #compile} would silently emit bytecode resolved against
+     * the previous target's classpath; after a reset, {@link #compile} instead throws the
+     * "not configured" error until {@link #configure} runs again for the new connection.
+     */
+    public synchronized void reset() {
+        this.jdkPath = null;
+        this.classpath = null;
+        this.targetMajorVersion = 8;
+    }
+
+    /**
      * Compiles `sourceCode` into bytecode for `className`. The returned map is keyed by fully qualified
      * class name and includes any inner/anonymous classes JDT emits.
      *

--- a/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
+++ b/jdwp-mcp-server/src/main/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluator.java
@@ -1126,13 +1126,18 @@ public class JdiExpressionEvaluator {
     /**
      * Configures the compiler with the target JVM's classpath. Skips if already configured for the
      * current connection. Automatically reconfigures after a disconnect/reconnect cycle (detected
-     * via null JDK path) and clears the compilation cache on reconfiguration because stale bytecode
-     * may reference classes from a previous connection. Must be called BEFORE any expression
-     * evaluation to avoid nested JDI calls.
+     * via null JDK path): clears the compilation cache AND resets the compiler config because stale
+     * bytecode and a stale classpath may reference classes from a previous connection. Must be
+     * called BEFORE any expression evaluation to avoid nested JDI calls.
      *
      * @param suspendedThread a thread already suspended at a breakpoint (REQUIRED)
+     * @throws JdiEvaluationException if classpath/JDK discovery fails for the current connection;
+     *                                the message is actionable and is surfaced to the user as an
+     *                                evaluation error or a {@code LOGPOINT_ERROR} event rather than
+     *                                left to manifest as a cryptic downstream JDT diagnostic
      */
-    public synchronized void configureCompilerClasspath(ThreadReference suspendedThread) {
+    public synchronized void configureCompilerClasspath(ThreadReference suspendedThread)
+        throws JdiEvaluationException {
         // Self-healing: if JDK path is already set, classpath is already configured for this connection
         if (jdiConnectionService.getDiscoveredJdkPath() != null) {
             return;
@@ -1145,36 +1150,69 @@ public class JdiExpressionEvaluator {
         final long guardedThreadId = suspendedThread.uniqueID();
         evaluationGuard.enter(guardedThreadId);
         try {
-            // New connection or reconnect — clear stale compilation cache
+            // A null discovered-JDK path means either first use on this connection or a
+            // post-reconnect cache wipe. Either way, any compiler state left over from a previous
+            // connection now points at the wrong target VM. Clear BOTH the compilation cache and
+            // the compiler config before rediscovering: if discovery then fails, compile() refuses
+            // with a clear "not configured" error instead of silently emitting bytecode resolved
+            // against the previous target's classpath.
             compilationCache.clear();
+            compiler.reset();
 
             final long startTime = System.currentTimeMillis();
 
-            try {
-                final String classpath = jdiConnectionService.discoverClasspath(suspendedThread);
-                final String jdkPath = jdiConnectionService.getDiscoveredJdkPath();
+            // discoverClasspath swallows its own failures (JdkNotFoundException, classloader-walk
+            // errors) and signals them by returning null / leaving the JDK path unset. Translate
+            // that into an actionable exception rather than returning silently — otherwise the
+            // caller proceeds to compile() and the user only sees a raw JDT diagnostic (e.g.
+            // "io cannot be resolved") with no hint that the real cause was a failed discovery.
+            final String classpath = jdiConnectionService.discoverClasspath(suspendedThread);
+            final String jdkPath = jdiConnectionService.getDiscoveredJdkPath();
 
-                if (jdkPath == null) {
-                    log.error("[Evaluator] JDK path not discovered, cannot configure compiler");
-                    return;
-                }
-
-                final int version = jdiConnectionService.getTargetMajorVersion();
-                if (classpath != null && !classpath.isEmpty()) {
-                    compiler.configure(jdkPath, classpath, version);
-
-                    final long elapsed = System.currentTimeMillis() - startTime;
-                    log.info("[Evaluator] Compiler configured in {}ms", elapsed);
-                } else {
-                    log.error("[Evaluator] Failed to discover classpath, expression evaluation may fail for application classes");
-                }
-
-            } catch (Exception e) {
-                final long elapsed = System.currentTimeMillis() - startTime;
-                log.error("[Evaluator] Error configuring classpath after {}ms", elapsed, e);
+            if (jdkPath == null) {
+                throw new JdiEvaluationException(
+                    "Classpath discovery failed for the current connection: no local JDK matching "
+                        + "the target VM could be located, so application types cannot be resolved. "
+                        + "Check the server log (search '[JDI]') for the underlying cause.");
             }
+            if (classpath == null || classpath.isEmpty()) {
+                throw new JdiEvaluationException(
+                    "Classpath discovery failed for the current connection: the target VM classpath "
+                        + "could not be determined, so application types cannot be resolved. "
+                        + "Check the server log (search '[JDI]') for the underlying cause.");
+            }
+
+            final int version = jdiConnectionService.getTargetMajorVersion();
+            compiler.configure(jdkPath, classpath, version);
+            log.info("[Evaluator] Compiler configured in {}ms", System.currentTimeMillis() - startTime);
         } finally {
             evaluationGuard.exit(guardedThreadId);
+        }
+    }
+
+    /**
+     * Best-effort pre-warm of the compiler classpath at the first thread suspension, so the agent's
+     * first {@code evaluate_expression} (or the first logpoint/condition hit) does not pay the
+     * one-time classpath discovery cost — which can take 1-3s while it walks the target VM's
+     * classloader hierarchy via {@code invokeMethod} — on the critical path. Discovery is paid once
+     * per connection; subsequent calls short-circuit on the cached JDK path.
+     * <p>
+     * Unlike {@link #configureCompilerClasspath}, this NEVER throws: it is invoked from the JDI
+     * event listener while a thread is parked for inspection, and a warming failure must not disrupt
+     * the breakpoint flow. Any failure is logged at debug and left for the real evaluation call to
+     * re-attempt and surface with a precise error.
+     *
+     * @param suspendedThread a thread already suspended at a breakpoint/step/exception/watchpoint
+     */
+    public void prewarmClasspath(ThreadReference suspendedThread) {
+        if (jdiConnectionService.getDiscoveredJdkPath() != null) {
+            return;
+        }
+        try {
+            configureCompilerClasspath(suspendedThread);
+        } catch (Exception e) {
+            log.debug("[Evaluator] Classpath pre-warm failed (will retry on first evaluation): {}",
+                e.getMessage());
         }
     }
 

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/InMemoryJavaCompilerConfigureTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/InMemoryJavaCompilerConfigureTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests {@link InMemoryJavaCompiler#configure(String, String, int)} — specifically the
@@ -80,6 +81,55 @@ class InMemoryJavaCompilerConfigureTest {
 				Map<String, byte[]> result = compiler.compile("EmptyClasspathTest", source);
 				assertThat(result).containsKey("EmptyClasspathTest");
 			}).doesNotThrowAnyException();
+		}
+	}
+
+	@Nested
+	@DisplayName("Reset")
+	class Reset {
+
+		@Test
+		@DisplayName("After reset, compile throws the not-configured error instead of using stale config")
+		void shouldThrowNotConfiguredAfterReset() {
+			final String jdkHome = System.getProperty("java.home");
+			compiler.configure(jdkHome, "", 17);
+
+			// Sanity: configured compiler compiles fine.
+			final String source = "public class ResetProbe { public static String run() { return \"ok\"; } }";
+			assertThatCode(() -> compiler.compile("ResetProbe", source)).doesNotThrowAnyException();
+
+			compiler.reset();
+
+			// After reset the compiler must behave as never-configured: compile() refuses rather
+			// than silently reusing the previous connection's JDK/classpath.
+			assertThatThrownBy(() -> compiler.compile("ResetProbe", source))
+				.isInstanceOf(JdiEvaluationException.class)
+				.hasMessageContaining("not configured");
+		}
+
+		@Test
+		@DisplayName("Reset clears jdkPath, classpath, and restores the default target version")
+		void shouldClearConfiguredState() throws Exception {
+			final String jdkHome = System.getProperty("java.home");
+			compiler.configure(jdkHome, "/some/app.jar", 21);
+
+			compiler.reset();
+
+			assertThat(readField("jdkPath")).isNull();
+			assertThat(readField("classpath")).isNull();
+			assertThat(readTargetMajorVersion()).isEqualTo(8);
+		}
+
+		private Object readField(String name) throws Exception {
+			final Field field = InMemoryJavaCompiler.class.getDeclaredField(name);
+			field.setAccessible(true);
+			return field.get(compiler);
+		}
+
+		private int readTargetMajorVersion() throws Exception {
+			final Field field = InMemoryJavaCompiler.class.getDeclaredField("targetMajorVersion");
+			field.setAccessible(true);
+			return (int) field.get(compiler);
 		}
 	}
 }

--- a/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorConfigureClasspathTest.java
+++ b/jdwp-mcp-server/src/test/java/one/edee/mcp/jdwp/evaluation/JdiExpressionEvaluatorConfigureClasspathTest.java
@@ -1,0 +1,118 @@
+package one.edee.mcp.jdwp.evaluation;
+
+import com.sun.jdi.ThreadReference;
+import one.edee.mcp.jdwp.EvaluationGuard;
+import one.edee.mcp.jdwp.JDIConnectionService;
+import one.edee.mcp.jdwp.evaluation.exceptions.JdiEvaluationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests the discovery-failure and pre-warm semantics of
+ * {@link JdiExpressionEvaluator#configureCompilerClasspath(ThreadReference)} and
+ * {@link JdiExpressionEvaluator#prewarmClasspath(ThreadReference)}.
+ *
+ * <p>Covers the fixes for the classpath-warming lifecycle (GH #30): a failed discovery must reset
+ * the compiler (so no stale config survives), surface an actionable exception from the strict path,
+ * and stay silent on the best-effort pre-warm path.
+ */
+class JdiExpressionEvaluatorConfigureClasspathTest {
+
+	private InMemoryJavaCompiler compiler;
+	private JDIConnectionService jdiService;
+	private JdiExpressionEvaluator evaluator;
+	private ThreadReference thread;
+
+	@BeforeEach
+	void setUp() {
+		compiler = mock(InMemoryJavaCompiler.class);
+		jdiService = mock(JDIConnectionService.class);
+		evaluator = new JdiExpressionEvaluator(compiler, jdiService, new EvaluationGuard());
+		thread = mock(ThreadReference.class);
+		when(thread.uniqueID()).thenReturn(42L);
+	}
+
+	@Test
+	@DisplayName("Discovery failure (no JDK) throws an actionable JdiEvaluationException")
+	void shouldThrowWhenJdkNotDiscovered() {
+		// Not cached → proceed into discovery; discovery leaves the JDK path null → failure.
+		when(jdiService.getDiscoveredJdkPath()).thenReturn(null);
+		when(jdiService.discoverClasspath(thread)).thenReturn(null);
+
+		assertThatThrownBy(() -> evaluator.configureCompilerClasspath(thread))
+			.isInstanceOf(JdiEvaluationException.class)
+			.hasMessageContaining("Classpath discovery failed")
+			.hasMessageContaining("application types cannot be resolved");
+	}
+
+	@Test
+	@DisplayName("Discovery failure resets the compiler and never configures it with stale state")
+	void shouldResetCompilerOnDiscoveryFailure() {
+		when(jdiService.getDiscoveredJdkPath()).thenReturn(null);
+		when(jdiService.discoverClasspath(thread)).thenReturn(null);
+
+		assertThatThrownBy(() -> evaluator.configureCompilerClasspath(thread))
+			.isInstanceOf(JdiEvaluationException.class);
+
+		verify(compiler).reset();
+		verify(compiler, never()).configure(any(), any(), org.mockito.ArgumentMatchers.anyInt());
+	}
+
+	@Test
+	@DisplayName("Already-configured connection short-circuits without touching the compiler")
+	void shouldShortCircuitWhenAlreadyConfigured() throws Exception {
+		// A non-null discovered JDK path means the connection is already configured.
+		when(jdiService.getDiscoveredJdkPath()).thenReturn("/opt/jdk");
+
+		evaluator.configureCompilerClasspath(thread);
+
+		verify(compiler, never()).reset();
+		verify(compiler, never()).configure(any(), any(), org.mockito.ArgumentMatchers.anyInt());
+		verify(jdiService, never()).discoverClasspath(any());
+	}
+
+	@Test
+	@DisplayName("Successful discovery resets then configures the compiler with discovered values")
+	void shouldConfigureOnSuccessfulDiscovery() throws Exception {
+		// First call (guard) returns null so we proceed; second call (post-discovery) returns the path.
+		when(jdiService.getDiscoveredJdkPath()).thenReturn(null, "/opt/jdk");
+		when(jdiService.discoverClasspath(thread)).thenReturn("/app/classes:/app/lib.jar");
+		when(jdiService.getTargetMajorVersion()).thenReturn(21);
+
+		evaluator.configureCompilerClasspath(thread);
+
+		verify(compiler).reset();
+		verify(compiler).configure("/opt/jdk", "/app/classes:/app/lib.jar", 21);
+	}
+
+	@Test
+	@DisplayName("prewarmClasspath swallows a discovery failure instead of throwing")
+	void prewarmShouldNotThrowOnFailure() {
+		when(jdiService.getDiscoveredJdkPath()).thenReturn(null);
+		when(jdiService.discoverClasspath(thread)).thenReturn(null);
+
+		assertThatCode(() -> evaluator.prewarmClasspath(thread)).doesNotThrowAnyException();
+		verify(compiler).reset();
+	}
+
+	@Test
+	@DisplayName("prewarmClasspath short-circuits when the connection is already configured")
+	void prewarmShouldShortCircuitWhenConfigured() {
+		when(jdiService.getDiscoveredJdkPath()).thenReturn("/opt/jdk");
+
+		evaluator.prewarmClasspath(thread);
+
+		verify(jdiService, never()).discoverClasspath(any());
+		verify(compiler, never()).reset();
+	}
+}


### PR DESCRIPTION
Closes #30.

Hardens the per-connection classpath discovery/caching that backs expression evaluation, logpoints, conditional breakpoints, and watchers. Surfaced by an agent that mis-diagnosed a post-reconnect `io cannot be resolved` logpoint failure.

## Changes

### Problem 1 — first-hit discovery latency on the listener thread
The one-time classpath discovery (~1–3 s, walks the target classloader hierarchy) ran lazily on the *first* `evaluate_expression` / logpoint hit. Added a best-effort `JdiExpressionEvaluator.prewarmClasspath()` and wired `JdiEventListener.listen()` to warm on the first suspending thread (breakpoint/step/exception/watchpoint) once the hit is recorded. Never throws out of the listener. Safe to drive `invokeMethod` from here for the same reason logpoint evaluation already is.

### Problem 2 — stale compiler config retained across disconnect/reconnect
`InMemoryJavaCompiler.jdkPath`/`classpath` were never reset, so a failed discovery on a fresh connection left `configureCompilerClasspath` returning silently and `compile()` proceeding against the **previous** target's classpath. Added `InMemoryJavaCompiler.reset()`, called in the rediscovery branch before discovery; a failed discovery now leaves the compiler unconfigured (`compile()` throws "not configured").

### Problem 3 — silent discovery failure → cryptic JDT error
`configureCompilerClasspath` now throws `JdiEvaluationException` with an actionable message when JDK/classpath discovery fails, instead of logging at ERROR and returning void. All call sites already catch `Exception`: eval tools return it as an error string; logpoint/condition paths record it as `LOGPOINT_ERROR`.

## Tests
- `InMemoryJavaCompilerConfigureTest` — `reset()` clears state and forces the not-configured error.
- New `JdiExpressionEvaluatorConfigureClasspathTest` (Mockito) — throw-on-failure, reset-on-failure, never-configure-with-stale-state, short-circuit when cached, configure-on-success, prewarm swallows failures.
- Full suite: **1013 pass, 0 fail, 2 skip**; main compile NullAway-clean.
